### PR TITLE
로또 6/45 기초 DB 구축 - 리포지토리, 서비스 개발

### DIFF
--- a/src/main/java/com/example/projectlottery/repository/LottoPrizeRepository.java
+++ b/src/main/java/com/example/projectlottery/repository/LottoPrizeRepository.java
@@ -1,0 +1,8 @@
+package com.example.projectlottery.repository;
+
+import com.example.projectlottery.domain.LottoPrize;
+import com.example.projectlottery.domain.id.LottoPrizeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LottoPrizeRepository extends JpaRepository<LottoPrize, LottoPrizeId> {
+}

--- a/src/main/java/com/example/projectlottery/repository/LottoRepository.java
+++ b/src/main/java/com/example/projectlottery/repository/LottoRepository.java
@@ -1,0 +1,7 @@
+package com.example.projectlottery.repository;
+
+import com.example.projectlottery.domain.Lotto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LottoRepository extends JpaRepository<Lotto, Long> {
+}

--- a/src/main/java/com/example/projectlottery/repository/LottoWinShopRepository.java
+++ b/src/main/java/com/example/projectlottery/repository/LottoWinShopRepository.java
@@ -1,0 +1,8 @@
+package com.example.projectlottery.repository;
+
+import com.example.projectlottery.domain.LottoWinShop;
+import com.example.projectlottery.domain.id.LottoWinShopId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LottoWinShopRepository extends JpaRepository<LottoWinShop, LottoWinShopId> {
+}

--- a/src/main/java/com/example/projectlottery/repository/ShopRepository.java
+++ b/src/main/java/com/example/projectlottery/repository/ShopRepository.java
@@ -3,5 +3,10 @@ package com.example.projectlottery.repository;
 import com.example.projectlottery.domain.Shop;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Set;
+
 public interface ShopRepository extends JpaRepository<Shop, Long> {
+
+    Set<Shop> findByL645YNAndScrapedDtBefore(boolean l645YN, LocalDate scrapedDt);
 }

--- a/src/main/java/com/example/projectlottery/service/LottoPrizeService.java
+++ b/src/main/java/com/example/projectlottery/service/LottoPrizeService.java
@@ -1,0 +1,21 @@
+package com.example.projectlottery.service;
+
+import com.example.projectlottery.dto.LottoPrizeDto;
+import com.example.projectlottery.repository.LottoPrizeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class LottoPrizeService {
+
+    private final LottoPrizeRepository lottoPrizeRepository;
+
+    public void save(LottoPrizeDto dto) {
+        lottoPrizeRepository.save(dto.toEntity());
+    }
+}

--- a/src/main/java/com/example/projectlottery/service/LottoService.java
+++ b/src/main/java/com/example/projectlottery/service/LottoService.java
@@ -1,0 +1,29 @@
+package com.example.projectlottery.service;
+
+import com.example.projectlottery.dto.LottoDto;
+import com.example.projectlottery.repository.LottoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class LottoService {
+
+    private final LottoRepository lottoRepository;
+
+    @Transactional(readOnly = true)
+    public LottoDto getLotto(Long drawNo) {
+        return lottoRepository.findById(drawNo)
+                .map(LottoDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("해당 회차가 없습니다. (drawNo: " + drawNo + ")"));
+    }
+
+    public void save(LottoDto dto) {
+        lottoRepository.save(dto.toEntity());
+    }
+}

--- a/src/main/java/com/example/projectlottery/service/LottoWinShopService.java
+++ b/src/main/java/com/example/projectlottery/service/LottoWinShopService.java
@@ -1,0 +1,21 @@
+package com.example.projectlottery.service;
+
+import com.example.projectlottery.dto.LottoWinShopDto;
+import com.example.projectlottery.repository.LottoWinShopRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class LottoWinShopService {
+
+    private final LottoWinShopRepository lottoWinShopRepository;
+
+    public void save(LottoWinShopDto dto) {
+        lottoWinShopRepository.save(dto.toEntity());
+    }
+}

--- a/src/main/java/com/example/projectlottery/service/ShopService.java
+++ b/src/main/java/com/example/projectlottery/service/ShopService.java
@@ -1,0 +1,37 @@
+package com.example.projectlottery.service;
+
+import com.example.projectlottery.dto.ShopDto;
+import com.example.projectlottery.repository.ShopRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ShopService {
+
+    private final ShopRepository shopRepository;
+    @Transactional(readOnly = true)
+    public Optional<ShopDto> getShopById(Long id) {
+        return shopRepository.findById(id).map(ShopDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<ShopDto> getShopByL645YNAndScrapedDt(boolean l645YN, LocalDate scrapedDt) {
+        return shopRepository.findByL645YNAndScrapedDtBefore(l645YN, scrapedDt).stream()
+                .map(ShopDto::from)
+                .collect(Collectors.toUnmodifiableSet()); //순서가 중요하지 않으므로 set 반환
+    }
+
+    public void save(ShopDto dto) {
+        shopRepository.save(dto.toEntity());
+    }
+}


### PR DESCRIPTION
해당 pr 은 로또 6/45 서비스를 위한 `repository`, `service` class 를 구현하는 작업이다.

1.`repository` 는 현재로선 `JPARepository` interface 를 상속받았기 때문에 별 게 없다.
다만, `ShopRepository` 의 `findByL645YNAndScrapedDtBefore()` 메소드는 더 이상 복권을 판매하지 않는 판매점을 처리할 때 사용할 예정이다. (`scrapedDt` < 현재일 and `l645YN` = true -> 과거에는 스크랩됐지만, 현재는 없으므로 폐업 처리)

2. `service` 도 현재로선 스크랩핑 데이터를 저장하기 위한 `save()` 말고는 별 게 없다.
다만, `Lotto`, `Shop` 은 주체적으로 사용되기에 `get()` 메소드를 추가로 구현했다. (다른 entity class 와 모두 연관관계를 갖고 있기에 이 둘만 조회해도 다른 테이블의 정보를 사용할 수 있다.)

3. `ShopService` 에는 추가적으로 `getShopByL645YNAndScrapedDt()` 메소드를 구현했다.
(추후 복권을 판매하지 않게 된 판매점에 대한 폐점 갱신처리를 하기 위한 목록을 조회한다. #28 참고)

This closes #19 