### PR TITLE
로또 6/45 기초 DB 구축 - 스크랩핑 서비스 개발

### DIFF
--- a/src/main/java/com/example/projectlottery/api/dto/GeoCoordinateToRegionDocsDto.java
+++ b/src/main/java/com/example/projectlottery/api/dto/GeoCoordinateToRegionDocsDto.java
@@ -1,0 +1,29 @@
+package com.example.projectlottery.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GeoCoordinateToRegionDocsDto {
+
+    @JsonProperty("region_type")
+    private String regionType;
+    @JsonProperty("address_name")
+    private String addressName;
+    @JsonProperty("region_1depth_name")
+    private String regionDepthName1;
+    @JsonProperty("region_2depth_name")
+    private String regionDepthName2;
+    @JsonProperty("region_3depth_name")
+    private String regionDepthName3;
+    @JsonProperty("code")
+    private String code;
+    @JsonProperty("x")
+    private String longitude;
+    @JsonProperty("y")
+    private String latitude;
+}

--- a/src/main/java/com/example/projectlottery/api/dto/GeoCoordinateToRegionMetaDto.java
+++ b/src/main/java/com/example/projectlottery/api/dto/GeoCoordinateToRegionMetaDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class MetaDto {
+public class GeoCoordinateToRegionMetaDto {
 
     @JsonProperty("total_count")
     private Integer totalCount;

--- a/src/main/java/com/example/projectlottery/api/dto/SearchAddressDocsDto.java
+++ b/src/main/java/com/example/projectlottery/api/dto/SearchAddressDocsDto.java
@@ -8,14 +8,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class DocumentsDto {
-
-    @JsonProperty("address_name")
-    private String addressName;
+public class SearchAddressDocsDto {
 
     @JsonProperty("x")
     private Double longitude;
-
     @JsonProperty("y")
     private Double latitude;
 }

--- a/src/main/java/com/example/projectlottery/api/dto/SearchAddressMetaDto.java
+++ b/src/main/java/com/example/projectlottery/api/dto/SearchAddressMetaDto.java
@@ -1,0 +1,15 @@
+package com.example.projectlottery.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchAddressMetaDto {
+
+    @JsonProperty("total_count")
+    private Integer totalCount;
+}

--- a/src/main/java/com/example/projectlottery/api/dto/response/KakaoGeoCoordinateToRegionResponse.java
+++ b/src/main/java/com/example/projectlottery/api/dto/response/KakaoGeoCoordinateToRegionResponse.java
@@ -1,0 +1,22 @@
+package com.example.projectlottery.api.dto.response;
+
+import com.example.projectlottery.api.dto.GeoCoordinateToRegionDocsDto;
+import com.example.projectlottery.api.dto.GeoCoordinateToRegionMetaDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoGeoCoordinateToRegionResponse {
+
+    @JsonProperty("meta")
+    private GeoCoordinateToRegionMetaDto meta;
+
+    @JsonProperty("documents")
+    private List<GeoCoordinateToRegionDocsDto> docs;
+}

--- a/src/main/java/com/example/projectlottery/api/dto/response/KakaoSearchAddressResponse.java
+++ b/src/main/java/com/example/projectlottery/api/dto/response/KakaoSearchAddressResponse.java
@@ -1,5 +1,7 @@
-package com.example.projectlottery.api.dto;
+package com.example.projectlottery.api.dto.response;
 
+import com.example.projectlottery.api.dto.SearchAddressDocsDto;
+import com.example.projectlottery.api.dto.SearchAddressMetaDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,8 +15,8 @@ import java.util.List;
 public class KakaoSearchAddressResponse {
 
     @JsonProperty("meta")
-    private MetaDto metaDto;
+    private SearchAddressMetaDto meta;
 
     @JsonProperty("documents")
-    private List<DocumentsDto> documentList;
+    private List<SearchAddressDocsDto> docs;
 }

--- a/src/main/java/com/example/projectlottery/api/service/ChromeDriverService.java
+++ b/src/main/java/com/example/projectlottery/api/service/ChromeDriverService.java
@@ -1,0 +1,110 @@
+package com.example.projectlottery.api.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChromeDriverService {
+
+    private static WebDriver webDriver;
+
+    public void openWebDriver() {
+        System.setProperty("webdriver.chrome.driver", "chromedriver");
+
+        ChromeOptions chromeOptions = new ChromeOptions();
+
+        //브라우저 숨김 처리
+        chromeOptions.addArguments("headless");
+        //headless 에러 방지
+        chromeOptions.addArguments("--start-maximized");
+        chromeOptions.addArguments("--window-size=1920,1080");
+        chromeOptions.addArguments("--disable-gpu");
+
+        webDriver = new ChromeDriver(chromeOptions);
+    }
+
+    public void closeWebDriver() {
+        webDriver.close();
+        webDriver.quit();
+    }
+
+    public void openUrl(String url, long sleepTime) {
+        try {
+            webDriver.get(url); //url 이동
+
+            //main 창 외 모든 창 닫기
+            String main = webDriver.getWindowHandle();
+            for (String handle : webDriver.getWindowHandles()) {
+                if(!handle.equals(main)) {
+                    webDriver.switchTo().window(handle).close();
+                }
+            }
+
+            //다시 main 창으로 변경
+            webDriver.switchTo().window(main);
+            Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void switchMainWindow(boolean toMain) {
+        webDriver.switchTo().window(webDriver.getWindowHandles().stream().toList().get(toMain ? 0 : 1));
+        if (toMain) {
+            webDriver.switchTo().window(webDriver.getWindowHandles().stream().toList().get(1)).close();
+            webDriver.switchTo().window(webDriver.getWindowHandles().stream().toList().get(0));
+        } else {
+            webDriver.switchTo().window(webDriver.getWindowHandles().stream().toList().get(1));
+        }
+    }
+
+    public WebElement getElementById(String id) {
+        return webDriver.findElement(By.id(id));
+    }
+
+    public List<WebElement> getElementsById(String id) {
+        return webDriver.findElements(By.id(id));
+    }
+
+    public WebElement getElementByCssSelector(String css) {
+        return webDriver.findElement(By.cssSelector(css));
+    }
+
+    public List<WebElement> getElementsByCssSelector(String css) {
+        return webDriver.findElements(By.cssSelector(css));
+    }
+
+
+    public void procJavaScript(String script, long sleepTime) {
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) webDriver;
+        jsExecutor.executeScript(script);
+
+        try {
+            Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void procJavaScript(String script, WebElement element, long sleepTime) {
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) webDriver;
+        jsExecutor.executeScript(script, element);
+
+        try {
+            Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/example/projectlottery/api/service/KakaoLocalApiService.java
+++ b/src/main/java/com/example/projectlottery/api/service/KakaoLocalApiService.java
@@ -1,6 +1,7 @@
 package com.example.projectlottery.api.service;
 
-import com.example.projectlottery.api.dto.KakaoSearchAddressResponse;
+import com.example.projectlottery.api.dto.response.KakaoGeoCoordinateToRegionResponse;
+import com.example.projectlottery.api.dto.response.KakaoSearchAddressResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +17,7 @@ import java.net.URI;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class KakaoSearchAddressService {
+public class KakaoLocalApiService {
 
     private final RestTemplate restTemplate;
 
@@ -25,6 +26,11 @@ public class KakaoSearchAddressService {
     @Value("${kakao.rest.api.key}")
     private String kakaoRestApiKey;
 
+    /**
+     * 주소 검색
+     * @param address 검색 대상 주소
+     * @return 위도, 경도 등 주소에 대한 정보
+     */
     public KakaoSearchAddressResponse requestSearchAddress(String address) {
         if (ObjectUtils.isEmpty(address)) {
             return null;
@@ -38,5 +44,22 @@ public class KakaoSearchAddressService {
         HttpEntity httpEntity = new HttpEntity(headers);
 
         return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoSearchAddressResponse.class).getBody();
+    }
+
+    /**
+     * 위도, 경도 좌표 검색
+     * @param longitude 위도
+     * @param latitude 경도
+     * @return 위도, 경도에 대한 행정구역 등 주소 정보
+     */
+    public KakaoGeoCoordinateToRegionResponse requestGeoCoordinateToRegion(double longitude, double latitude) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+
+        URI uri = uriBuilderService.buildUriByCoordinate(longitude, latitude);
+
+        HttpEntity httpEntity = new HttpEntity(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoGeoCoordinateToRegionResponse.class).getBody();
     }
 }

--- a/src/main/java/com/example/projectlottery/api/service/ScrapLotteryShopService.java
+++ b/src/main/java/com/example/projectlottery/api/service/ScrapLotteryShopService.java
@@ -1,0 +1,257 @@
+package com.example.projectlottery.api.service;
+
+import com.example.projectlottery.api.dto.GeoCoordinateToRegionDocsDto;
+import com.example.projectlottery.api.dto.response.KakaoGeoCoordinateToRegionResponse;
+import com.example.projectlottery.api.dto.response.KakaoSearchAddressResponse;
+import com.example.projectlottery.domain.type.ScrapStateType;
+import com.example.projectlottery.dto.ShopDto;
+import com.example.projectlottery.service.ShopService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ScrapLotteryShopService {
+
+    private static final String URL_SHOP_LOTTO = "https://www.dhlottery.co.kr/store.do?method=sellerInfo645";
+
+    private final ChromeDriverService chromeDriverService;
+    private final ShopService shopService;
+    private final KakaoLocalApiService kakaoLocalApiService;
+
+    /**
+     * 로또 6/45 판매점 정보 스크랩핑
+     *
+     * @param state 시.도
+     */
+    public void scrapShopL645(String state) {
+        chromeDriverService.openWebDriver();
+        chromeDriverService.openUrl(URL_SHOP_LOTTO, 200);
+
+        ScrapStateType shopScrapStateType = ScrapStateType.valueOf(state);
+
+        if (shopScrapStateType == ScrapStateType.ALL) {
+            Arrays.stream(ScrapStateType.values())
+                    .filter(scrapStateType -> scrapStateType.ordinal() > 0)
+                    .toList()
+                    .forEach(this::scrapShopL645ByState);
+        } else {
+            scrapShopL645ByState(shopScrapStateType);
+        }
+
+        //스크랩핑 완료 후, 판매 중단 대상 판매점 처리 (스크랩핑 일자가 과거면서 l645YN = true)
+        setShopWithdrawL645();
+
+        chromeDriverService.closeWebDriver();
+    }
+
+    /**
+     * 로또 6/45 판매점 정보 스크랩핑
+     *
+     * @param scrapStateType 시.도 Enum
+     */
+    private void scrapShopL645ByState(ScrapStateType scrapStateType) {
+        String css;
+        String js;
+
+        //타 시.도로 이동해 구 단위 필터 해제
+        if (scrapStateType == ScrapStateType.SEOUL) {
+            css = "#mainMenuArea > a:nth-child(2)";
+            js = chromeDriverService.getElementByCssSelector(css).getAttribute("onclick");
+            chromeDriverService.procJavaScript(js, 200);
+        }
+
+        //대상 시.도로 이동
+        css = "#mainMenuArea > a:nth-child(" + scrapStateType.ordinal() + ")";
+        js = chromeDriverService.getElementByCssSelector(css).getAttribute("onclick");
+        chromeDriverService.procJavaScript(js, 200);
+
+        //항상 1 페이지부터 시작할 수 있도록 설정
+        js = "$.selfSubmit(1);";
+        chromeDriverService.procJavaScript(js, 200);
+
+        //현재 pagination view 에 [끝 페이지] 링크가 존재하는지 확인
+        css = "#pagingView > a";
+        int firstPagingViewItemCount = chromeDriverService.getElementsByCssSelector(css).size();
+
+        //마지막 페이지 번호 획득
+        int lastPageNo = firstPagingViewItemCount;
+        if (firstPagingViewItemCount > 10) {
+            css = "#pagingView > a.go.end";
+            lastPageNo = Integer.parseInt(chromeDriverService.getElementByCssSelector(css)
+                    .getAttribute("href")
+                    .replaceAll("[^0-9]", ""));
+        }
+
+        int curPageNo = 1;
+        while (curPageNo <= lastPageNo) {
+            //항상 1 페이지부터 시작할 수 있도록 세팅
+            js = "$.selfSubmit(" + curPageNo + ");";
+            chromeDriverService.procJavaScript(js, 200);
+
+            css = "#resultTable > tbody > tr";
+            List<WebElement> Shops = chromeDriverService.getElementsByCssSelector(css);
+
+            for (WebElement shop : Shops) {
+                //판매점 id 획득
+                Long id = Long.parseLong(shop.findElement(By.cssSelector("td:nth-child(4) > a"))
+                        .getAttribute("onclick")
+                        .replaceAll("[^0-9]", "")
+                );
+
+                //상호명, 전화번호, 주소 정보 획득
+                String name = shop.findElement(By.cssSelector("td:nth-child(1)")).getText();
+                String tel = shop.findElement(By.cssSelector("td:nth-child(2)")).getText();
+                String address = shop.findElement(By.cssSelector("td:nth-child(3)")).getText();
+
+                //해당 주소에 대한 위도, 경도 정보 획득
+                double[] geoCoordinate = getGeoCoordinateByAddress(
+                        address,
+                        shop.findElement(By.cssSelector("td:nth-child(4) > a")).getAttribute("onclick")
+                );
+                double longitude = geoCoordinate[0];
+                double latitude = geoCoordinate[1];
+
+                //해당 위도, 경도에 대한 행정구역 정보 획득
+                String[] states = getStateByGeoCoordinate(longitude, latitude);
+                String state1 = states[0];
+                String state2 = states[1];
+                String state3 = states[2];
+
+                //판매점이 db에 없으면, 신규 레코드로 저장
+                //판매점이 db에 있으면, 가게 상세정보 업데이트 (단, 연금복권과 스피또 판매여부는 여기서 설정하지 않는다.)
+                ShopDto shopDto = shopService.getShopById(id).map(dto -> ShopDto.of(
+                        dto.id(),
+                        address,
+                        name,
+                        tel,
+                        longitude,
+                        latitude,
+                        true,
+                        dto.l720YN(),
+                        dto.spYN(),
+                        state1,
+                        state2,
+                        state3,
+                        LocalDate.now()
+                )).orElseGet(() -> ShopDto.of(
+                        id,
+                        address,
+                        name,
+                        tel,
+                        longitude,
+                        latitude,
+                        true,
+                        false,
+                        false,
+                        state1,
+                        state2,
+                        state3,
+                        LocalDate.now()
+                ));
+
+                shopService.save(shopDto);
+            }
+
+            curPageNo++;
+        }
+    }
+
+    /**
+     * 로또 판매 중단 판매점 처리
+     */
+    private void setShopWithdrawL645() {
+        //스크랩핑 일자가 과거면서 l645YN = true 인 목록은 판매 중단 처리
+        Set<ShopDto> shopDtos = shopService.getShopByL645YNAndScrapedDt(true, LocalDate.now());
+        for (ShopDto shopDto : shopDtos) {
+            shopService.save(ShopDto.of(
+                    shopDto.id(),
+                    shopDto.address(),
+                    shopDto.name(),
+                    shopDto.tel(),
+                    shopDto.longitude(),
+                    shopDto.latitude(),
+                    false,
+                    shopDto.l720YN(),
+                    shopDto.spYN(),
+                    shopDto.state1(),
+                    shopDto.state2(),
+                    shopDto.state3(),
+                    shopDto.scrapedDt()
+            ));
+        }
+    }
+
+    /**
+     * 주소에 대한 위도, 경도 조회
+     *
+     * @param address 주소
+     * @param jsOpenPopWindow 동행복권 위치보기 팝업 js
+     * @return 위도, 경도
+     */
+    public double[] getGeoCoordinateByAddress(String address, String jsOpenPopWindow) {
+        double longitude;
+        double latitude;
+
+        //최우선으로 카카오 주소 검색 API 결과의 위도, 경도를 획득한다.
+        //정확히 1개의 결과가 반환되었을 때만 정확한 좌표로 판단하고 적용하기로 한다.
+        KakaoSearchAddressResponse searchAddressResponse = kakaoLocalApiService.requestSearchAddress(address);
+        if (searchAddressResponse.getMeta().getTotalCount() == 1) {
+            longitude = searchAddressResponse.getDocs().get(0).getLongitude();
+            latitude = searchAddressResponse.getDocs().get(0).getLatitude();
+        } else {
+            //차선책으로 동행복권에서 제공하는 위치보기 팝업창에서 위도, 경도를 획득한다.
+            chromeDriverService.procJavaScript(jsOpenPopWindow, 200);
+
+            chromeDriverService.switchMainWindow(false);
+            longitude = Double.parseDouble(
+                    chromeDriverService.getElementByCssSelector("body > form > input[type=hidden]:nth-child(2)").getAttribute("value"));
+            latitude = Double.parseDouble(
+                    chromeDriverService.getElementByCssSelector("body > form > input[type=hidden]:nth-child(1)").getAttribute("value"));
+            chromeDriverService.switchMainWindow(true);
+        }
+
+        return new double[]{longitude, latitude};
+    }
+
+    /**
+     * 위도, 경도에 대한 행정구역 정보 조회
+     * @param longitude 위도
+     * @param latitude 경도
+     * @return 행정구역 정보 (시.도/시.군.구/읍.면.동)
+     */
+    public String[] getStateByGeoCoordinate(double longitude, double latitude) {
+        String state1 = ""; //시.도
+        String state2 = ""; //시.군.구
+        String state3 = ""; //읍.면.동
+
+        KakaoGeoCoordinateToRegionResponse geoCoordinateToRegionResponse = kakaoLocalApiService.requestGeoCoordinateToRegion(longitude, latitude);
+        if (geoCoordinateToRegionResponse.getMeta().getTotalCount() > 0) {
+            //행정동 행정구역 데이터가 있는지 체크
+            Optional<GeoCoordinateToRegionDocsDto> hTypeRegion = geoCoordinateToRegionResponse.getDocs().stream()
+                    .filter(doc -> doc.getRegionType().equals("H"))
+                    .findFirst();
+
+            Optional<GeoCoordinateToRegionDocsDto> bTypeRegion = geoCoordinateToRegionResponse.getDocs().stream()
+                    .filter(doc -> doc.getRegionType().equals("B"))
+                    .findFirst();
+
+            //행정동 데이터가 없으면 법정동 데이터로 설정
+            state1 = hTypeRegion.orElse(bTypeRegion.orElse(new GeoCoordinateToRegionDocsDto())).getRegionDepthName1();
+            state2 = hTypeRegion.orElse(bTypeRegion.orElse(new GeoCoordinateToRegionDocsDto())).getRegionDepthName2();
+            state3 = hTypeRegion.orElse(bTypeRegion.orElse(new GeoCoordinateToRegionDocsDto())).getRegionDepthName3();
+        }
+
+        return new String[]{state1, state2, state3};
+    }
+}

--- a/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinService.java
+++ b/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinService.java
@@ -1,0 +1,95 @@
+package com.example.projectlottery.api.service;
+
+import com.example.projectlottery.dto.LottoDto;
+import com.example.projectlottery.dto.LottoPrizeDto;
+import com.example.projectlottery.service.LottoService;
+import com.example.projectlottery.service.LottoPrizeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ScrapLotteryWinService {
+    private static final String URL_RESULT_LOTTO = "https://www.dhlottery.co.kr/gameResult.do?method=byWin";
+
+    private final ChromeDriverService chromeDriverService;
+    private final LottoService lottoService;
+    private final LottoPrizeService lottoPrizeService;
+
+    //TODO: 신규 회차만 가져오는 메서드를 만들고 이를 잡에서 사용해 매주 새로운 추첨 회자 정보를 스크랩핑할 수 있도록 한다.
+
+    /**
+     * 로또 6/45 회차별 당첨 번호 + 등위별 당첨 금액 스크랩핑
+     *
+     * @param start 시작 회차
+     * @param end   종료 회차
+     */
+    public void getResultsL645(long start, long end) {
+        chromeDriverService.openWebDriver();
+        chromeDriverService.openUrl(URL_RESULT_LOTTO, 200);
+
+        for (long i = start; i <= end; i++) {
+            getNumbersL645(i);
+            getPrizesL645(i);
+        }
+
+        chromeDriverService.closeWebDriver();
+    }
+
+    private void getNumbersL645(long drawNo) {
+        Select select = new Select(chromeDriverService.getElementById("dwrNoList"));
+        select.selectByValue(String.valueOf(drawNo)); //회차 변경
+
+        String js = "document.getElementById('searchBtn').click();";
+        chromeDriverService.procJavaScript(js, 200); //회차 조회
+
+        //추첨일
+        String css = "#article > div:nth-child(2) > div > div.win_result > p";
+        String strDrawDt = chromeDriverService.getElementByCssSelector(css).getText().replaceAll("[^0-9]", "");
+        LocalDate drawDt = LocalDate.of(
+                Integer.parseInt(strDrawDt.substring(0, 4)),
+                Integer.parseInt(strDrawDt.substring(4, 6)),
+                Integer.parseInt(strDrawDt.substring(6, 8))
+        );
+
+        //당첨번호
+        css = "#article > div:nth-child(2) > div > div.win_result > div > div.num.win > p > span";
+        Set<Integer> numbers = chromeDriverService.getElementsByCssSelector(css)
+                .stream().map(WebElement::getText)
+                .map(Integer::parseInt)
+                .collect(Collectors.toUnmodifiableSet());
+
+        //보너스 번호
+        css = "#article > div:nth-child(2) > div > div.win_result > div > div.num.bonus > p > span";
+        Integer bonus = Integer.parseInt(chromeDriverService.getElementByCssSelector(css).getText());
+
+        LottoDto dto = LottoDto.of(drawNo, drawDt, numbers, bonus);
+        lottoService.save(dto);
+    }
+
+    private void getPrizesL645(long drawNo) {
+        for (int i = 1; i <= 5; i++) {
+            //등위별 당첨자 수 + 당첨 금액
+            String css = "#article > div:nth-child(2) > div > table > tbody > tr:nth-child(" + i + ") > td";
+            List<WebElement> prizes = chromeDriverService.getElementsByCssSelector(css);
+
+            LottoDto lottoDto = lottoService.getLotto(drawNo);
+            Integer rank = i;
+            long amount = Long.parseLong(prizes.get(1).getText().replaceAll("[^0-9]", ""));
+            long winningCount = Long.parseLong(prizes.get(2).getText().replaceAll("[^0-9]", ""));
+            long amountPerGame = Long.parseLong(prizes.get(3).getText().replaceAll("[^0-9]", ""));
+
+            LottoPrizeDto lottoPrizeDto = LottoPrizeDto.of(lottoDto, rank, amount, winningCount, amountPerGame);
+            lottoPrizeService.save(lottoPrizeDto);
+        }
+    }
+}

--- a/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinShopService.java
+++ b/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinShopService.java
@@ -1,0 +1,213 @@
+package com.example.projectlottery.api.service;
+
+import com.example.projectlottery.domain.type.LottoPurchaseType;
+import com.example.projectlottery.dto.LottoDto;
+import com.example.projectlottery.dto.LottoWinShopDto;
+import com.example.projectlottery.dto.ShopDto;
+import com.example.projectlottery.service.LottoService;
+import com.example.projectlottery.service.LottoWinShopService;
+import com.example.projectlottery.service.ShopService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ScrapLotteryWinShopService {
+
+    private static final String URL_SHOP_WINNING_LOTTO = "https://www.dhlottery.co.kr/store.do?method=topStore&pageGubun=L645";
+
+    private final ChromeDriverService chromeDriverService;
+    private final LottoService lottoService;
+    private final ShopService shopService;
+    private final LottoWinShopService lottoWinShopService;
+    private final ScrapLotteryShopService scrapLotteryShopService;
+
+
+    /**
+     * 로또 6/45 당첨 판매점 정보 스크랩핑
+     *
+     * @param start 시작 회차
+     * @param end   종료 회차
+     */
+    public void getWinShopL645(long start, long end) {
+        chromeDriverService.openWebDriver();
+        chromeDriverService.openUrl(URL_SHOP_WINNING_LOTTO, 200);
+
+        for (long i = start; i <= end; i++) {
+            getWinShopL645_1st(i);
+            getWinShopL645_2nd(i);
+        }
+
+        chromeDriverService.closeWebDriver();
+    }
+
+    /**
+     * 로또 6/45 1등 당첨 판매점 정보 스크랩핑
+     *
+     * @param drawNo 회차
+     */
+    private void getWinShopL645_1st(long drawNo) {
+        setSelectDrawNo(drawNo);
+
+        String js = "document.getElementById('searchBtn').click();";
+        chromeDriverService.procJavaScript(js, 200);
+
+        //1등 복권 판매점 목록 획득
+        String css = "#article > div:nth-child(2) > div > div:nth-child(4) > table > tbody > tr";
+        List<WebElement> shops = chromeDriverService.getElementsByCssSelector(css);
+
+        for (int i = 1; i <= shops.size(); i++) {
+            //판매점 정보 획득
+            css = "#article > div:nth-child(2) > div > div:nth-child(4) > table > tbody > tr:nth-child(" + i + ") > td";
+            List<WebElement> shopInfos = chromeDriverService.getElementsByCssSelector(css);
+
+            //1등 당첨자 없는 회차 대응
+            if (shopInfos.size() == 1 && shopInfos.get(0).getText().equals("조회 결과가 없습니다.")) {
+                break;
+            }
+
+            saveWinShopL645(drawNo, 1, shopInfos);
+        }
+    }
+
+    /**
+     * 로또 6/45 2등 당첨 판매점 정보 스크랩핑
+     *
+     * @param drawNo 회차
+     */
+    private void getWinShopL645_2nd(long drawNo) {
+        String css = "#page_box > a";
+        int pageCount = chromeDriverService.getElementsByCssSelector(css).size();
+
+        for (int i = 1; i <= pageCount; i++) {
+            setSelectDrawNo(drawNo);
+
+            if (i > 1) { //2번째 페이지부터 자바스크립트를 실행해 페이지를 이동
+                String js = "selfSubmit(" + i + ");";
+                chromeDriverService.procJavaScript(js, 200);
+            }
+
+            css = "#article > div:nth-child(2) > div > div:nth-child(5) > table > tbody > tr";
+            int shopCount = chromeDriverService.getElementsByCssSelector(css).size();
+
+            for (int j = 1; j <= shopCount; j++) {
+                css = "#article > div:nth-child(2) > div > div:nth-child(5) > table > tbody > tr:nth-child(" + j + ") > td";
+                List<WebElement> shops = chromeDriverService.getElementsByCssSelector(css);
+
+                //당첨 정보 바인딩
+                saveWinShopL645(drawNo, 2, shops);
+            }
+        }
+    }
+
+    /**
+     * 회차 select option 변경
+     *
+     * @param drawNo 회차
+     */
+    private void setSelectDrawNo(long drawNo) {
+        String css = "#drwNo";
+        Select select = new Select(chromeDriverService.getElementByCssSelector(css));
+
+        //공식적으로 제공하는 가장 과거 회차 번호 힉득
+        List<WebElement> options = select.getOptions();
+        long pastDrawNo = Long.parseLong(options.get(options.size() - 1).getText());
+
+        if (drawNo >= pastDrawNo) {
+            //공식적으로 제공하는 회차는 select 옵션 변경해서 검색
+            select.selectByValue(String.valueOf(drawNo));
+        } else {
+            //나머지 회차는 강제로 select value 변경해서 검색
+            css = "#drwNo > option:nth-child(1)";
+            WebElement option = chromeDriverService.getElementByCssSelector(css);
+
+            String js = "arguments[0].value=" + drawNo + ";";
+            chromeDriverService.procJavaScript(js, option, 0);
+        }
+    }
+
+    /**
+     * 로또 6/45 당첨 판매점 정보 저장
+     *
+     * @param drawNo    회차
+     * @param r         등위
+     * @param shopInfos 당첨 판매점 정보 table (WebElement list)
+     */
+    private void saveWinShopL645(long drawNo, int r, List<WebElement> shopInfos) {
+        //당첨 정보 바인딩
+        LottoDto lottoDto = lottoService.getLotto(drawNo);
+        Integer rank = r;
+        Integer no = Integer.parseInt(shopInfos.get(0).getText());
+        LottoPurchaseType lottoPurchaseType = (r == 1 ?
+                LottoPurchaseType.getLottoType(shopInfos.get(2).getText()) : LottoPurchaseType.NONE);
+        String displayAddress = shopInfos.get(r == 1 ? 3 : 2).getText();
+
+        //판매점 id 획득
+        Long shopId = Long.parseLong(shopInfos.get(r == 1 ? 4 : 3).findElement(By.cssSelector("a"))
+                .getAttribute("onclick")
+                .replaceAll("[^0-9]", "")
+        );
+
+        //해당 판매점이 shop 테이블에 존재하면 그대로 FK 로 지정하고,
+        //그렇지 않으면 새로 shop 테이블에 저장하고, 해당 객체를 FK 로 지정한다. (orElseGet)
+        ShopDto shopDto = shopService.getShopById(shopId).orElseGet(() -> {
+            String address = shopInfos.get(r == 1 ? 3 : 2).getText();
+            String name = shopInfos.get(1).getText();
+            String tel = "";
+
+            //해당 주소에 대한 위도, 경도 정보 획득
+            double[] geoCoordinate = scrapLotteryShopService.getGeoCoordinateByAddress(
+                    address,
+                    shopInfos.get(r == 1 ? 4 : 3).findElement(By.cssSelector("a")).getAttribute("onclick")
+            );
+            double longitude = geoCoordinate[0];
+            double latitude = geoCoordinate[1];
+
+            //해당 위도, 경도에 대한 행정구역 정보 획득
+            String[] states = scrapLotteryShopService.getStateByGeoCoordinate(longitude, latitude);
+            String state1 = states[0];
+            String state2 = states[1];
+            String state3 = states[2];
+
+            //해당 판매점은 더 이상 복권을 판매하지 않는 것으로 간주하고, 모든 복권 판매 여부를 false 로 세팅
+            ShopDto dto = ShopDto.of(
+                    shopId,
+                    address,
+                    name,
+                    tel,
+                    longitude,
+                    latitude,
+                    false,
+                    false,
+                    false,
+                    state1,
+                    state2,
+                    state3,
+                    LocalDate.now()
+            );
+
+            shopService.save(dto);
+
+            return dto;
+        });
+
+        LottoWinShopDto lottoWinShopDto = LottoWinShopDto.of(
+                lottoDto,
+                rank,
+                no,
+                shopDto,
+                lottoPurchaseType,
+                displayAddress
+        );
+
+        lottoWinShopService.save(lottoWinShopDto);
+    }
+}

--- a/src/main/java/com/example/projectlottery/api/service/UriBuilderService.java
+++ b/src/main/java/com/example/projectlottery/api/service/UriBuilderService.java
@@ -11,6 +11,7 @@ import java.net.URI;
 public class UriBuilderService {
 
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private static final String KAKAO_GEO_COORDINATE_TO_REGION_URL = "https://dapi.kakao.com/v2/local/geo/coord2regioncode.json";
 
     public URI buildUriByAddress(String address) {
         UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
@@ -18,6 +19,17 @@ public class UriBuilderService {
 
         URI uri = builder.build().encode().toUri();
         log.info("[UriBuilderService buildUriByAddress] address: {}, uri: {}", address, uri);
+
+        return uri;
+    }
+
+    public URI buildUriByCoordinate(double longitude, double latitude) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(KAKAO_GEO_COORDINATE_TO_REGION_URL);
+        builder.queryParam("x", longitude);
+        builder.queryParam("y", latitude);
+
+        URI uri = builder.build().encode().toUri();
+        log.info("[UriBuilderService buildUriByAddress] longitude: {}, latitude: {}, uri: {}", longitude, latitude, uri);
 
         return uri;
     }

--- a/src/main/java/com/example/projectlottery/domain/type/ScrapStateType.java
+++ b/src/main/java/com/example/projectlottery/domain/type/ScrapStateType.java
@@ -1,0 +1,31 @@
+package com.example.projectlottery.domain.type;
+
+import lombok.Getter;
+
+public enum ScrapStateType {
+    ALL("전체"),
+    SEOUL("서울"),
+    GYEONGGI("경기"),
+    BUSAN("부산"),
+    DAEGU("대구"),
+    INCHEON("인천"),
+    DAEJEON("대전"),
+    ULSAN("울산"),
+    GANGWON("강원"),
+    CHUNGBUK("충북"),
+    CHUNGNAM("충남"),
+    GWANGJU("광주"),
+    JEONBUK("전북"),
+    JEONNAM("전남"),
+    GYEONGBUK("경북"),
+    GYEONGNAM("경남"),
+    JEJU("제주"),
+    SEJONG("세종");
+
+    @Getter
+    private final String description;
+
+    ScrapStateType(String description) {
+        this.description = description;
+    }
+}


### PR DESCRIPTION
해당 pr 에서 동행복권 사이트에서 복권 관련 정보를 스크랩핑 하는 서비스를 개발했다.

1. 회차별 당청번호, 등위별 당첨게임 수, 등위별 당첨금액
2. 복권 판매점 정보 (상호명, 소재지, 위도, 경도 등)
3. 회차별 당첨 판매점 정보 (262회차부터 제공)

1번은 스크랩핑한 정보를 그대로 db 에 저장하면 되므로 별 게 없었다.

2번은 소재지가 불분명한 판매점이 존재해 카카오 로컬 API 중에서 위도, 경도를 검색하는 API 를 추가적으로 구현해 행정구역 정보를 획득해 저장하도록 했다. (추후, 행정구역 정보는 판매점 검색에 사용)

3번은 과거 회차에 존재했던 판매점이 더 이상 판매하지 않는 경우가 꽤 많아, 어떻게 관리할지 고민을 많이 했다. 일단 무조건 `shop` 테이블에 레코드를 생성하는 편이 관리하기 용이하다고 생각했기 때문에 해당 소재지를 카카오 주소검색 API 를 통해 위도와 경도, 행정구역 정보를 획득하도록 구현했다. 그리고 나서 `lotto` 와 `shop` 모두와 연관관계를 맺도록 FK 로 지정해 레코드로 저장했다.

This closes #23 