### PR TITLE
지역별 로또 6/45 판매점 검색 기능 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Environments ###
 .env
+
+### Querydsl
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,21 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'org.seleniumhq.selenium:selenium-java:4.8.1'
+    implementation 'org.seleniumhq.selenium:selenium-java'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //Querydsl 의존성 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+
+    //java.lang.NoClassDefFoundError 대응을 위해 추가
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
     //spock
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
@@ -49,4 +57,22 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+//Querydsl Q Class 생성 위치
+def generated = 'src/main/generated'
+
+//Querydsl Q Class 생성 위치 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+//java source set 에 Querydsl Q Class 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+//gradle clean 시, Q Class 디렉토리까지 삭제하도록 설정
+clean {
+    delete file(generated)
 }

--- a/src/main/java/com/example/projectlottery/controller/ShopController.java
+++ b/src/main/java/com/example/projectlottery/controller/ShopController.java
@@ -1,13 +1,21 @@
 package com.example.projectlottery.controller;
 
 import com.example.projectlottery.dto.response.shop.ShopResponse;
+import com.example.projectlottery.service.PaginationService;
+import com.example.projectlottery.service.RegionService;
 import com.example.projectlottery.service.ShopService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -16,6 +24,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class ShopController {
 
     private final ShopService shopService;
+    private final RegionService regionService;
+    private final PaginationService paginationService;
 
     @GetMapping
     public String shop(@RequestParam String shopId, ModelMap map) {
@@ -23,5 +33,26 @@ public class ShopController {
         map.addAttribute("shopResponse", shopResponse);
 
         return "/shop/detail";
+    }
+
+    @GetMapping("/list")
+    public String shops(
+            @RequestParam(required = false) String state1,
+            @RequestParam(required = false) String state2,
+            @PageableDefault(sort = "address", direction = Sort.Direction.ASC) Pageable pageable,
+            ModelMap map
+    ) {
+        Page<ShopResponse> shops = shopService.getShopListResponse(state1, state2, pageable);
+        List<Integer> pagination = paginationService.getPagination(pageable.getPageNumber(), shops.getTotalPages());
+
+        List<String> state1List = regionService.getAllState1();
+        List<String> state2List = regionService.getAllState2(state1);
+
+        map.addAttribute("shops", shops);
+        map.addAttribute("pagination", pagination);
+        map.addAttribute("state1List", state1List);
+        map.addAttribute("state2List", state2List);
+
+        return "/shop/list";
     }
 }

--- a/src/main/java/com/example/projectlottery/domain/Region.java
+++ b/src/main/java/com/example/projectlottery/domain/Region.java
@@ -1,0 +1,46 @@
+package com.example.projectlottery.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+        @Index(columnList = "reg"),
+        @Index(columnList = "state1"),
+        @Index(columnList = "state2"),
+        @Index(columnList = "parentReg"),
+})
+@Entity
+public class Region {
+
+    @Column(length = 5)
+    @Id
+    private String reg;
+
+    @Column
+    private String state1;
+
+    @Column
+    private String state2;
+
+    @Column(updatable = false, length = 5)
+    private String parentReg;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Region region)) return false;
+        return reg != null && reg.equals(region.reg);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reg);
+    }
+}

--- a/src/main/java/com/example/projectlottery/dto/response/shop/ShopResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/shop/ShopResponse.java
@@ -9,6 +9,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 public record ShopResponse(
+        Long id,
         String name,
         String address,
         String tel,
@@ -26,8 +27,8 @@ public record ShopResponse(
         Set<ShopLottoWinResponse> lotto2ndWin
 ) {
 
-    public static ShopResponse of(String name, String address, String tel, double longitude, double latitude, boolean l645YN, boolean l720YN, boolean spYN, long count1stWin, long count1stWinAuto, long count1stWinManual, long count1stWinMix, long count2ndWin, Set<ShopLottoWinResponse> lotto1stWin, Set<ShopLottoWinResponse> lotto2ndWin) {
-        return new ShopResponse(name, address, tel, longitude, latitude, l645YN, l720YN, spYN, count1stWin, count1stWinAuto, count1stWinManual, count1stWinMix, count2ndWin, lotto1stWin, lotto2ndWin);
+    public static ShopResponse of(Long id, String name, String address, String tel, double longitude, double latitude, boolean l645YN, boolean l720YN, boolean spYN, long count1stWin, long count1stWinAuto, long count1stWinManual, long count1stWinMix, long count2ndWin, Set<ShopLottoWinResponse> lotto1stWin, Set<ShopLottoWinResponse> lotto2ndWin) {
+        return new ShopResponse(id, name, address, tel, longitude, latitude, l645YN, l720YN, spYN, count1stWin, count1stWinAuto, count1stWinManual, count1stWinMix, count2ndWin, lotto1stWin, lotto2ndWin);
     }
 
     public static ShopResponse from(Shop entity) {
@@ -47,6 +48,7 @@ public record ShopResponse(
                 .count();
 
         return ShopResponse.of(
+                entity.getId(),
                 entity.getName(),
                 entity.getAddress(),
                 entity.getTel(),

--- a/src/main/java/com/example/projectlottery/repository/RegionRepository.java
+++ b/src/main/java/com/example/projectlottery/repository/RegionRepository.java
@@ -1,0 +1,13 @@
+package com.example.projectlottery.repository;
+
+import com.example.projectlottery.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RegionRepository extends JpaRepository<Region, String> {
+
+    List<Region> findAllByParentRegIsNull();
+
+    List<Region> findAllByParentReg(String parentReg);
+}

--- a/src/main/java/com/example/projectlottery/repository/ShopRepository.java
+++ b/src/main/java/com/example/projectlottery/repository/ShopRepository.java
@@ -1,12 +1,29 @@
 package com.example.projectlottery.repository;
 
+import com.example.projectlottery.domain.QShop;
 import com.example.projectlottery.domain.Shop;
+import com.example.projectlottery.repository.querydsl.ShopRepositoryCustom;
+import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 
 import java.time.LocalDate;
 import java.util.Set;
 
-public interface ShopRepository extends JpaRepository<Shop, Long> {
+public interface ShopRepository extends
+        JpaRepository<Shop, Long>,
+        ShopRepositoryCustom,
+        QuerydslPredicateExecutor<Shop>,
+        QuerydslBinderCustomizer<QShop> {
 
     Set<Shop> findByL645YNAndScrapedDtBefore(boolean l645YN, LocalDate scrapedDt);
+
+    @Override
+    default void customize(QuerydslBindings bindings, QShop root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.name);
+        bindings.bind(root.name).first(StringExpression::contains);
+    }
 }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustom.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.projectlottery.repository.querydsl;
+
+import com.example.projectlottery.domain.Shop;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ShopRepositoryCustom {
+
+    Page<Shop> findByStates(String state1, String state2, Pageable pageable);
+}

--- a/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.example.projectlottery.repository.querydsl;
+
+import com.example.projectlottery.domain.QShop;
+import com.example.projectlottery.domain.Shop;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.util.StringUtils;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ShopRepositoryCustomImpl extends QuerydslRepositorySupport implements ShopRepositoryCustom {
+
+    private QShop shop;
+
+    public ShopRepositoryCustomImpl() {
+        super(Shop.class);
+        this.shop = QShop.shop;
+    }
+
+    @Override
+    public Page<Shop> findByStates(String state1, String state2, Pageable pageable) {
+        JPQLQuery<Shop> query = from(shop)
+                .where(state1Eq(state1), state2Eq(state2), shop.l645YN.eq(true));
+
+        List<Shop> shops = getQuerydsl().applyPagination(pageable, query).fetch();
+
+        return new PageImpl<>(shops, pageable, query.fetchCount());
+    }
+
+    private BooleanExpression state1Eq(String state1) {
+        return StringUtils.isNullOrEmpty(state1) ? null : shop.state1.eq(state1);
+    }
+
+    private BooleanExpression state2Eq(String state2) {
+        return StringUtils.isNullOrEmpty(state2) ? null : shop.state2.eq(state2);
+    }
+
+
+}

--- a/src/main/java/com/example/projectlottery/service/PaginationService.java
+++ b/src/main/java/com/example/projectlottery/service/PaginationService.java
@@ -1,0 +1,21 @@
+package com.example.projectlottery.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+public class PaginationService {
+
+    private static final int MAX_PRINT_LENGTH = 5; //최대 표시 페이지 수
+
+    public List<Integer> getPagination(int curPage, int totalPages) {
+        int start = Math.max(curPage - MAX_PRINT_LENGTH / 2, 0);
+        int end = Math.min(start + MAX_PRINT_LENGTH, totalPages);
+
+        start = start > end - MAX_PRINT_LENGTH ? Math.max(end - MAX_PRINT_LENGTH, 0) : start;
+
+        return IntStream.range(start, end).boxed().toList();
+    }
+}

--- a/src/main/java/com/example/projectlottery/service/RegionService.java
+++ b/src/main/java/com/example/projectlottery/service/RegionService.java
@@ -1,0 +1,41 @@
+package com.example.projectlottery.service;
+
+import com.example.projectlottery.domain.Region;
+import com.example.projectlottery.repository.RegionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class RegionService {
+
+    private final RegionRepository regionRepository;
+
+    public List<String> getAllState1() {
+        return regionRepository.findAllByParentRegIsNull().stream()
+                .map(Region::getState1)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getAllState2(String state1) {
+        if (!StringUtils.hasText(state1))
+            return List.of();
+
+        String parentReg = regionRepository.findAllByParentRegIsNull().stream()
+                .filter(region -> region.getState1().equals(state1))
+                .findFirst()
+                .get().getReg();
+
+        return regionRepository.findAllByParentReg(parentReg).stream()
+                .map(Region::getState2)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/projectlottery/service/ShopService.java
+++ b/src/main/java/com/example/projectlottery/service/ShopService.java
@@ -6,6 +6,8 @@ import com.example.projectlottery.repository.ShopRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +40,13 @@ public class ShopService {
     public ShopResponse getShopResponse(Long id) {
         return shopRepository.findById(id)
                 .map(ShopResponse::from)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회차가 없습니다. (id: " + id + ")"));
+                .orElseThrow(() -> new EntityNotFoundException("해당 판매점 없습니다. (id: " + id + ")"));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ShopResponse> getShopListResponse(String state1, String state2, Pageable pageable) {
+        return shopRepository.findByStates(state1, state2, pageable)
+                .map(ShopResponse::from);
     }
 
 

--- a/src/main/resources/static/css/shopList.css
+++ b/src/main/resources/static/css/shopList.css
@@ -1,0 +1,50 @@
+.search-group {
+    margin-bottom: 15px;
+    display: grid;
+    grid-template-columns: 49% 2% 49%;
+}
+
+.state-group {
+    display: grid;
+    grid-template-columns: 25% 25% 25% 25%;
+}
+
+.search-input-group {
+    justify-content: flex-end;
+}
+
+.state-group a {
+    font-size: 13px;
+    text-decoration: none;
+}
+
+.state-selected {
+    background: #87ccfd;
+}
+
+.search-group h2 {
+    margin-top: 15px;
+    width: 120px;
+    height: 40px;
+}
+
+.search-group a {
+    width: 120px;
+    height: 40px;
+}
+.search-group input {
+    margin-top: 15px;
+    width: 200px;
+    height: 40px;
+}
+
+.search-group button {
+    width: 40px;
+    height: 40px;
+    margin-top: 15px;
+    margin-left: 5px;
+}
+
+.table-hover tr:hover {
+    cursor: pointer;
+}

--- a/src/main/resources/templates/shop/list.html
+++ b/src/main/resources/templates/shop/list.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" charset="PARK GI-PYO">
+    <title>project-lottery</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="/css/shopList.css" rel="stylesheet">
+</head>
+<body>
+<header id="header">
+    header 삽입부
+    <hr>
+</header>
+<main class="container">
+    <div class="row">
+        <form action="/shop/list" method="get">
+            <div class="search-group">
+                <div>
+                    <h2>시도</h2>
+                    <div id="state1" class="form-control state-group">
+                        <a class="form-control">전체</a>
+                        <a class="form-control">서울특별시</a>
+                    </div>
+                </div>
+                <div></div>
+                <div>
+                    <h2>시군구</h2>
+                    <div id="state2" class="form-control state-group">
+                        <a class="form-control">전체</a>
+                        <a class="form-control"></a>
+                    </div>
+                </div>
+<!--                <div></div>-->
+<!--                <div></div>-->
+<!--                <div class="row search-input-group">-->
+<!--                    <h2>상호명</h2>-->
+<!--                    <input type="text" name="shop-name" class="form-control">-->
+<!--                    <button class="btn btn-primary" type="submit">-->
+<!--                        <i class="fa fa-search"></i>-->
+<!--                    </button>-->
+<!--                </div>-->
+            </div>
+        </form>
+
+        <!-- BEGIN TABLE RESULT -->
+        <div class="table-responsive">
+            <table class="table table-hover" id="shop-table">
+                <thead class="thead-center">
+                <tr>
+                    <th class="col">상호명</th>
+                    <th class="col">소재지</th>
+                    <th class="col">1등</th>
+                    <th class="col">2등</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td class="name col col-center">인터넷 복권판매사이트</td>
+                    <td class="address col col-center">동행복권(dhlottery.co.kr)</td>
+                    <td class="count-1st-win col col-center">0</td>
+                    <td class="count-2nd-win col col-center">0</td>
+                </tr>
+                <tr>
+                    <td class="name col col-center">인터넷 복권판매사이트</td>
+                    <td class="address col col-center">동행복권(dhlottery.co.kr)</td>
+                    <td class="count-1st-win col col-center">0</td>
+                    <td class="count-2nd-win col col-center">0</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!-- END TABLE RESULT -->
+
+        <!-- BEGIN PAGINATION -->
+        <nav id="pagination">
+            <ul class="pagination justify-content-center">
+                <li class="page-item disabled"><a class="page-link" href="#">«</a></li>
+                <li class="page-item disabled"><a class="page-link" href="#">‹</a></li>
+                <li class="page-item active"><a class="page-link" href="#">1</a></li>
+                <li class="page-item"><a class="page-link" href="#">›</a></li>
+                <li class="page-item"><a class="page-link" href="#">»</a></li>
+            </ul>
+        </nav>
+        <!-- END PAGINATION -->
+    </div>
+</main>
+<footer id="footer">
+    <hr>
+    footer 삽입부
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/shop/list.th.xml
+++ b/src/main/resources/templates/shop/list.th.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" ?>
+<thlogic>
+    <attr sel="#state1">
+        <attr sel="a[0]"
+              th:href="@{/shop/list(
+                            page=${0},
+                            state1=${''},
+                            state2=${''}
+                      )}"
+              th:classappend="${param.state1.toString == '' ? 'state-selected' : ''}"
+        />
+        <attr sel="a[1]"
+              th:each="state : ${state1List}"
+              th:text="${state}"
+              th:href="@{/shop/list(
+                            page=${0},
+                            state1=${state},
+                            state2=${''}
+                      )}"
+              th:classappend="${param.state1.toString == state.toString ? 'state-selected' : ''}"
+        />
+    </attr>
+
+    <attr sel="#state2">
+        <attr sel="a[0]"
+              th:href="@{/shop/list(
+                            page=${0},
+                            state1=${param.state1},
+                            state2=${''}
+                      )}"
+              th:classappend="${param.state2.toString == '' ? 'state-selected' : ''}"
+        />
+        <attr sel="a[1]"
+              th:each="state : ${state2List}"
+              th:text="${state}"
+              th:href="@{/shop/list(
+                            page=${0},
+                            state1=${param.state1},
+                            state2=${state}
+                      )}"
+              th:classappend="${param.state2.toString == state.toString ? 'state-selected' : ''}"
+        />
+    </attr>
+
+    <attr sel="#shop-table">
+        <attr sel="tbody" th:remove="all-but-first">
+            <attr sel="tr[0]" th:each="shop : ${shops}" th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
+                <attr sel="td[0]" th:text="${shop.name}"/>
+                <attr sel="td[1]" th:text="${shop.address}"/>
+                <attr sel="td[2]" th:text="${shop.count1stWin}"/>
+                <attr sel="td[3]" th:text="${shop.count2ndWin}"/>
+            </attr>
+        </attr>
+    </attr>
+
+    <attr sel="#pagination">
+        <attr sel="ul">
+            <attr sel="li[0]" th:class="'page-item' + (${shops.number} <= 0 ? ' disabled' : '')">
+                <attr sel="a" th:text="'«'"
+                      th:class="'page-link' + (${shops.number} <= 0 ? ' disabled' : '')"
+                      th:href="@{/shop/list(
+                            page=${0},
+                            state1=${param.state1},
+                            state2=${param.state2}
+                      )}"
+                />
+            </attr>
+            <attr sel="li[1]" th:class="'page-item' + (${shops.number} <= 0 ? ' disabled' : '')">
+                <attr sel="a" th:text="'‹'"
+                      th:class="'page-link' + (${shops.number} <= 0 ? ' disabled' : '')"
+                      th:href="@{/shop/list(
+                            page=${shops.number - 1},
+                            state1=${param.state1},
+                            state2=${param.state2}
+                      )}"
+                />
+            </attr>
+            <attr sel="li[2]" th:each="pageNumber : ${pagination}"
+                  th:class="'page-item' + (${shops.number} == ${pageNumber} ? ' active' : '')">
+                <attr sel="a" th:text="${pageNumber + 1}"
+                      th:href="@{/shop/list(
+                            page=${pageNumber},
+                            state1=${param.state1},
+                            state2=${param.state2}
+                      )}"
+                />
+            </attr>
+            <attr sel="li[3]"
+                  th:class="'page-item' + (${shops.number + 1} >= ${shops.totalPages} ? ' disabled' : '')">
+                <attr sel="a" th:text="'›'"
+                      th:class="'page-link' + (${shops.number + 1} >= ${shops.totalPages} ? ' disabled' : '')"
+                      th:href="@{/shop/list(
+                            page=${shops.number + 1},
+                            state1=${param.state1},
+                            state2=${param.state2}
+                      )}"
+                />
+            </attr>
+            <attr sel="li[4]"
+                  th:class="'page-item' + (${shops.number + 1} >= ${shops.totalPages} ? ' disabled' : '')">
+                <attr sel="a" th:text="'»'"
+                      th:class="'page-link' + (${shops.number + 1} >= ${shops.totalPages} ? ' disabled' : '')"
+                      th:href="@{/shop/list(
+                            page=${shops.totalPages - 1},
+                            state1=${param.state1},
+                            state2=${param.state2}
+                      )}"
+                />
+            </attr>
+        </attr>
+    </attr>
+</thlogic>


### PR DESCRIPTION
해당 pr 에서 시도, 시군구 별 로또 6/45 판매점 목록을 조회할 수 있도록 하는 기능과 view 를 개발했다.

목록 정렬 기능은 따로 제공하지 않을 예정이다.
왜냐하면, 소재지 기준으로 정렬처리 했고, 명당 목록 조회 기능을 따로 제공할 예정이기 때문이다.

This closes #34 