### PR TITLE
로또 6/45 판매점 랭킹 제공 기능 개발

### DIFF
--- a/src/main/java/com/example/projectlottery/controller/ShopController.java
+++ b/src/main/java/com/example/projectlottery/controller/ShopController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
+import java.util.TreeSet;
 
 
 @RequiredArgsConstructor
@@ -54,5 +55,15 @@ public class ShopController {
         map.addAttribute("state2List", state2List);
 
         return "/shop/list";
+    }
+
+
+    @GetMapping("/ranking")
+    public String ranking(ModelMap map) {
+        TreeSet<ShopResponse> ranking = shopService.getShopRankingResponse();
+
+        map.addAttribute("ranking", ranking);
+
+        return "/shop/ranking";
     }
 }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustom.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustom.java
@@ -4,7 +4,10 @@ import com.example.projectlottery.domain.Shop;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ShopRepositoryCustom {
 
     Page<Shop> findByStates(String state1, String state2, Pageable pageable);
+    List<Shop> findByWins();
 }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.repository.querydsl;
 
+import com.example.projectlottery.domain.QLottoWinShop;
 import com.example.projectlottery.domain.QShop;
 import com.example.projectlottery.domain.Shop;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -15,10 +16,13 @@ import java.util.List;
 public class ShopRepositoryCustomImpl extends QuerydslRepositorySupport implements ShopRepositoryCustom {
 
     private QShop shop;
+    private QLottoWinShop lottoWinShop;
 
     public ShopRepositoryCustomImpl() {
         super(Shop.class);
+
         this.shop = QShop.shop;
+        this.lottoWinShop = QLottoWinShop.lottoWinShop;
     }
 
     @Override
@@ -39,5 +43,18 @@ public class ShopRepositoryCustomImpl extends QuerydslRepositorySupport implemen
         return StringUtils.isNullOrEmpty(state2) ? null : shop.state2.eq(state2);
     }
 
+    @Override
+    public List<Shop> findByWins() {
+        List<Long> shopIdWin1st = from(lottoWinShop)
+                .where(lottoWinShop.shop.l645YN.eq(true), lottoWinShop.rank.eq(1)) //판매중지 아닌 판매점 중에서 1등 배출 판매점
+                .groupBy(lottoWinShop.shop.id) //group by
+                .select(lottoWinShop.shop.id)
+                .orderBy(lottoWinShop.count().desc()) //1등 배출 횟수 내림차순
+                .limit(100) //상위 100건
+                .fetch();
 
+        return from(shop)
+                .where(shop.id.in(shopIdWin1st))
+                .fetch();
+    }
 }

--- a/src/main/java/com/example/projectlottery/service/ShopService.java
+++ b/src/main/java/com/example/projectlottery/service/ShopService.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.service;
 
+import com.example.projectlottery.domain.Shop;
 import com.example.projectlottery.dto.ShopDto;
 import com.example.projectlottery.dto.response.shop.ShopResponse;
 import com.example.projectlottery.repository.ShopRepository;
@@ -12,8 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -49,6 +49,18 @@ public class ShopService {
                 .map(ShopResponse::from);
     }
 
+    @Transactional(readOnly = true)
+    public TreeSet<ShopResponse> getShopRankingResponse() {
+        List<Shop> byWins = shopRepository.findByWins();
+
+        return byWins.stream().map(ShopResponse::from)
+                .collect(Collectors.toCollection(() ->
+                        new TreeSet<>(Comparator.comparing(ShopResponse::count1stWin) //1등 배출횟수
+                                .thenComparing(ShopResponse::count1stWinAuto) //자동 1등 배출횟수
+                                .thenComparing(ShopResponse::count2ndWin) //2등 배출횟수
+                                .reversed() //앞의 조건까지 내림차순 처리
+                                .thenComparing(ShopResponse::id))));
+    }
 
     public void save(ShopDto dto) {
         shopRepository.save(dto.toEntity());

--- a/src/main/resources/templates/shop/ranking.html
+++ b/src/main/resources/templates/shop/ranking.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" charset="PARK GI-PYO">
+    <title>project-lottery</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="/css/shopRanking.css" rel="stylesheet">
+</head>
+<body>
+<header id="header">
+    header 삽입부
+    <hr>
+</header>
+<main class="container">
+    <div class="row">
+        <div class="title">
+            <h2>로또 명당 <span class="text-red">TOP 100</span></h2>
+            <h6><span class="text-red">★262회차</span>부터 집계</h6>
+        </div>
+        <!-- BEGIN TABLE RESULT -->
+        <div class="table-responsive">
+            <table class="table table-hover" id="ranking-table">
+                <thead class="thead-center">
+                <tr>
+                    <th class="col">순위</th>
+                    <th class="col">상호명</th>
+                    <th class="col">소재지</th>
+                    <th class="col">1등</th>
+                    <th class="col">2등</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td class="rank col col-center">1</td>
+                    <td class="name col col-center">인터넷 복권판매사이트</td>
+                    <td class="address col col-center">동행복권(dhlottery.co.kr)</td>
+                    <td class="count-1st-win col col-center">0</td>
+                    <td class="count-2nd-win col col-center">0</td>
+                </tr>
+                <tr>
+                    <td class="rank col col-center">2</td>
+                    <td class="name col col-center">인터넷 복권판매사이트</td>
+                    <td class="address col col-center">동행복권(dhlottery.co.kr)</td>
+                    <td class="count-1st-win col col-center">0</td>
+                    <td class="count-2nd-win col col-center">0</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <!-- END TABLE RESULT -->
+    </div>
+</main>
+<footer id="footer">
+    <hr>
+    footer 삽입부
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/shop/ranking.th.xml
+++ b/src/main/resources/templates/shop/ranking.th.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<thlogic>
+    <attr sel="#ranking-table">
+        <attr sel="tbody" th:remove="all-but-first">
+            <attr sel="tr[0]" th:each="shop, stat : ${ranking}" th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
+                <attr sel="td[0]" th:text="${stat.index + 1}"/>
+                <attr sel="td[1]" th:text="${shop.name}"/>
+                <attr sel="td[2]" th:text="${shop.address}"/>
+                <attr sel="td[3]" th:text="${shop.count1stWin}"/>
+                <attr sel="td[4]" th:text="${shop.count2ndWin}"/>
+            </attr>
+        </attr>
+    </attr>
+</thlogic>


### PR DESCRIPTION
해당 pr 은 판매점 랭킹 구현 관련 작업이다.

QueryDSL 을 이용해 필터링과 적절한 정렬 작업을 통해 랭킹을 구현했다.
1. `LottoWinShop` 테이블에서 판매정지(L645YN)가 아닌 판매점 중 1등 배출 판매점 목록 조회 
2. 위 목록에서 group by 처리 후, 내림차순 정렬하여 상위 100건을 조회

위 쿼리 결과를 service 단에서 새로 treeSet 을 만듦과 동시에 세부 정렬 조건을 주어 정렬한다.
1. 1등 배출 횟수 내림차순
2. 1등 자동 배출 횟수 내림차순
3. 2등 배출 횟수 내림차순

추후, 성능을 고려하여 redis 를 적용해볼 수 있을 것 같다.

This closes #37 