### PR TITLE
JPA Auditing - 생성, 수정일시

### DIFF
--- a/src/main/java/com/example/projectlottery/ProjectLotteryApplication.java
+++ b/src/main/java/com/example/projectlottery/ProjectLotteryApplication.java
@@ -2,7 +2,9 @@ package com.example.projectlottery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ProjectLotteryApplication {
 

--- a/src/main/java/com/example/projectlottery/domain/Lotto.java
+++ b/src/main/java/com/example/projectlottery/domain/Lotto.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.domain;
 
+import com.example.projectlottery.domain.auditing.AuditingFields;
 import com.example.projectlottery.domain.embedded.LottoWinNumber;
 import jakarta.persistence.*;
 import lombok.*;
@@ -14,7 +15,7 @@ import java.util.Set;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Lotto {
+public class Lotto extends AuditingFields {
 
     @Id
     private Long drawNo; //회차

--- a/src/main/java/com/example/projectlottery/domain/LottoPrize.java
+++ b/src/main/java/com/example/projectlottery/domain/LottoPrize.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.domain;
 
+import com.example.projectlottery.domain.auditing.AuditingFields;
 import com.example.projectlottery.domain.id.LottoPrizeId;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @IdClass(LottoPrizeId.class)
 @Entity
-public class LottoPrize {
+public class LottoPrize extends AuditingFields {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @Id

--- a/src/main/java/com/example/projectlottery/domain/LottoWinShop.java
+++ b/src/main/java/com/example/projectlottery/domain/LottoWinShop.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.domain;
 
+import com.example.projectlottery.domain.auditing.AuditingFields;
 import com.example.projectlottery.domain.id.LottoWinShopId;
 import com.example.projectlottery.domain.type.LottoPurchaseType;
 import jakarta.persistence.*;
@@ -11,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @IdClass(LottoWinShopId.class)
 @Entity
-public class LottoWinShop {
+public class LottoWinShop extends AuditingFields {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @Id

--- a/src/main/java/com/example/projectlottery/domain/Region.java
+++ b/src/main/java/com/example/projectlottery/domain/Region.java
@@ -1,10 +1,12 @@
 package com.example.projectlottery.domain;
 
+import com.example.projectlottery.domain.auditing.AuditingFields;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 @ToString
@@ -17,7 +19,7 @@ import java.util.Objects;
         @Index(columnList = "parentReg"),
 })
 @Entity
-public class Region {
+public class Region extends AuditingFields {
 
     @Column(length = 5)
     @Id

--- a/src/main/java/com/example/projectlottery/domain/Shop.java
+++ b/src/main/java/com/example/projectlottery/domain/Shop.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.domain;
 
+import com.example.projectlottery.domain.auditing.AuditingFields;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -15,7 +16,7 @@ import java.util.Set;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Shop {
+public class Shop extends AuditingFields {
 
     @Id
     private Long id; //판매점 id

--- a/src/main/java/com/example/projectlottery/domain/auditing/AuditingFields.java
+++ b/src/main/java/com/example/projectlottery/domain/auditing/AuditingFields.java
@@ -1,0 +1,25 @@
+package com.example.projectlottery.domain.auditing;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
해당 pr 은 entity 관리 목적으로 생성일시, 수정일시 필드를 JPA Auditing 기능을 적용한 작업이다.

This closes #45