### PR TITLE
redis 적용

### DIFF
--- a/src/main/java/com/example/projectlottery/config/ObjectMapperConfig.java
+++ b/src/main/java/com/example/projectlottery/config/ObjectMapperConfig.java
@@ -1,0 +1,14 @@
+package com.example.projectlottery.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/example/projectlottery/config/RedisConfig.java
+++ b/src/main/java/com/example/projectlottery/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.example.projectlottery.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/projectlottery/dto/response/lotto/LottoResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/lotto/LottoResponse.java
@@ -3,9 +3,7 @@ package com.example.projectlottery.dto.response.lotto;
 import com.example.projectlottery.domain.Lotto;
 
 import java.util.Comparator;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
+import java.util.List;
 
 public record LottoResponse(
         Long drawNo,
@@ -17,12 +15,12 @@ public record LottoResponse(
         int number5,
         int number6,
         int bonus,
-        Set<LottoPrizeResponse> lottoPrizes,
-        Set<LottoWinShopResponse> lotto1stWinShops,
-        Set<LottoWinShopResponse> lotto2ndWinShops
+        List<LottoPrizeResponse> lottoPrizes,
+        List<LottoWinShopResponse> lotto1stWinShops,
+        List<LottoWinShopResponse> lotto2ndWinShops
 ) {
 
-    public static LottoResponse of(Long drawNo, String drawDt, int number1, int number2, int number3, int number4, int number5, int number6, int bonus, Set<LottoPrizeResponse> lottoPrizes, Set<LottoWinShopResponse> lottoWinShops1st, Set<LottoWinShopResponse> lottoWinShops2nd) {
+    public static LottoResponse of(Long drawNo, String drawDt, int number1, int number2, int number3, int number4, int number5, int number6, int bonus, List<LottoPrizeResponse> lottoPrizes, List<LottoWinShopResponse> lottoWinShops1st, List<LottoWinShopResponse> lottoWinShops2nd) {
         return new LottoResponse(
                 drawNo,
                 drawDt,
@@ -52,18 +50,18 @@ public record LottoResponse(
                 entity.getLottoWinNumber().getNumberB(),
                 entity.getLottoPrizes().stream()
                         .map(LottoPrizeResponse::from)
-                        .collect(Collectors.toCollection(() ->
-                                new TreeSet<>(Comparator.comparing(LottoPrizeResponse::rank)))), //등위로 정렬
+                        .sorted(Comparator.comparing(LottoPrizeResponse::rank))
+                        .toList(), //등위로 정렬
                 entity.getLottoWinShops().stream()
                         .filter(lottoWinShop -> lottoWinShop.getRank() == 1)
                         .map(LottoWinShopResponse::from)
-                        .collect(Collectors.toCollection(() ->
-                                new TreeSet<>(Comparator.comparing(LottoWinShopResponse::no)))), //순번으로 정렬 (1등)
+                        .sorted(Comparator.comparing(LottoWinShopResponse::no))
+                        .toList(), //순번으로 정렬 (1등)
                 entity.getLottoWinShops().stream()
                         .filter(lottoWinShop -> lottoWinShop.getRank() == 2)
                         .map(LottoWinShopResponse::from)
-                        .collect(Collectors.toCollection(() ->
-                                new TreeSet<>(Comparator.comparing(LottoWinShopResponse::no)))) //순번으로 정렬 (2등)
+                        .sorted(Comparator.comparing(LottoWinShopResponse::no))
+                        .toList() //순번으로 정렬 (2등)
         );
     }
 }

--- a/src/main/java/com/example/projectlottery/dto/response/shop/ShopResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/shop/ShopResponse.java
@@ -4,9 +4,7 @@ import com.example.projectlottery.domain.Shop;
 import com.example.projectlottery.domain.type.LottoPurchaseType;
 
 import java.util.Comparator;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
+import java.util.List;
 
 public record ShopResponse(
         Long id,
@@ -23,11 +21,11 @@ public record ShopResponse(
         long count1stWinManual,
         long count1stWinMix,
         long count2ndWin,
-        Set<ShopLottoWinResponse> lotto1stWin,
-        Set<ShopLottoWinResponse> lotto2ndWin
+        List<ShopLottoWinResponse> lotto1stWin,
+        List<ShopLottoWinResponse> lotto2ndWin
 ) {
 
-    public static ShopResponse of(Long id, String name, String address, String tel, double longitude, double latitude, boolean l645YN, boolean l720YN, boolean spYN, long count1stWin, long count1stWinAuto, long count1stWinManual, long count1stWinMix, long count2ndWin, Set<ShopLottoWinResponse> lotto1stWin, Set<ShopLottoWinResponse> lotto2ndWin) {
+    public static ShopResponse of(Long id, String name, String address, String tel, double longitude, double latitude, boolean l645YN, boolean l720YN, boolean spYN, long count1stWin, long count1stWinAuto, long count1stWinManual, long count1stWinMix, long count2ndWin, List<ShopLottoWinResponse> lotto1stWin, List<ShopLottoWinResponse> lotto2ndWin) {
         return new ShopResponse(id, name, address, tel, longitude, latitude, l645YN, l720YN, spYN, count1stWin, count1stWinAuto, count1stWinManual, count1stWinMix, count2ndWin, lotto1stWin, lotto2ndWin);
     }
 
@@ -65,17 +63,17 @@ public record ShopResponse(
                 entity.getLottoWinShops().stream()
                         .filter(lottoWinShop -> lottoWinShop.getRank() == 1)
                         .map(ShopLottoWinResponse::from)
-                        .collect(Collectors.toCollection(() ->
-                                new TreeSet<>(Comparator.comparing(ShopLottoWinResponse::drawNo)
-                                        .reversed()
-                                        .thenComparing(ShopLottoWinResponse::no)))),
+                        .sorted(Comparator.comparing(ShopLottoWinResponse::drawNo)
+                                .reversed()
+                                .thenComparing(ShopLottoWinResponse::no))
+                        .toList(),
                 entity.getLottoWinShops().stream()
                         .filter(lottoWinShop -> lottoWinShop.getRank() == 2)
                         .map(ShopLottoWinResponse::from)
-                        .collect(Collectors.toCollection(() ->
-                                new TreeSet<>(Comparator.comparing(ShopLottoWinResponse::drawNo)
-                                        .reversed()
-                                        .thenComparing(ShopLottoWinResponse::no))))
+                        .sorted(Comparator.comparing(ShopLottoWinResponse::drawNo)
+                                .reversed()
+                                .thenComparing(ShopLottoWinResponse::no))
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/example/projectlottery/service/LottoService.java
+++ b/src/main/java/com/example/projectlottery/service/LottoService.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Slf4j
 @Transactional
 @RequiredArgsConstructor
@@ -16,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class LottoService {
 
     private final LottoRepository lottoRepository;
+
+    private final RedisTemplateService redisTemplateService;
 
     @Transactional(readOnly = true)
     public LottoDto getLotto(Long drawNo) {
@@ -26,14 +30,30 @@ public class LottoService {
 
     @Transactional(readOnly = true)
     public Long getLatestDrawNo() {
-        return lottoRepository.getLatestDrawNo();
+        Long latestDrawNo = redisTemplateService.getLatestDrawNo();
+
+        if (Objects.isNull(latestDrawNo)) { //redis 조회 실패 시, redis 갱신
+            latestDrawNo = lottoRepository.getLatestDrawNo();
+
+            redisTemplateService.saveLatestDrawNo(latestDrawNo);
+        }
+
+        return latestDrawNo;
     }
 
     @Transactional(readOnly = true)
     public LottoResponse getLottoResponse(Long drawNo) {
-        return lottoRepository.findById(drawNo)
-                .map(LottoResponse::from)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회차가 없습니다. (drawNo: " + drawNo + ")"));
+        LottoResponse lottoResponse = redisTemplateService.getWinDetail(drawNo);
+
+        if (Objects.isNull(lottoResponse)) { //redis 조회 실패 시, redis 갱신
+            lottoResponse = lottoRepository.findById(drawNo)
+                    .map(LottoResponse::from)
+                    .orElseThrow(() -> new EntityNotFoundException("해당 회차가 없습니다. (drawNo: " + drawNo + ")"));
+
+            redisTemplateService.saveWinDetail(lottoResponse);
+        }
+
+        return lottoResponse;
     }
 
     public void save(LottoDto dto) {

--- a/src/main/java/com/example/projectlottery/service/RedisTemplateService.java
+++ b/src/main/java/com/example/projectlottery/service/RedisTemplateService.java
@@ -1,0 +1,169 @@
+package com.example.projectlottery.service;
+
+import com.example.projectlottery.dto.response.lotto.LottoResponse;
+import com.example.projectlottery.dto.response.shop.ShopResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.*;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisTemplateService {
+    private static final String CACHE_LATEST_DRAW_NO_KEY = "L645_LATEST_DRAW_NO";
+    private static final String CACHE_WIN_DETAIL_KEY = "L645_WIN_DETAIL";
+    private static final String CACHE_SHOP_DETAIL_KEY = "L645_SHOP_DETAIL";
+    private static final String CACHE_SHOP_RANKING_KEY = "L645_SHOP_RANKING";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private final ObjectMapper objectMapper;
+
+    private ValueOperations<String, Object> valueOperations;
+    private HashOperations<String, String, String> hashOperations;
+    private ZSetOperations<String, Object> zSetOperations;
+
+    @PostConstruct
+    public void init() {
+        valueOperations = redisTemplate.opsForValue();
+        hashOperations = redisTemplate.opsForHash();
+        zSetOperations = redisTemplate.opsForZSet();
+    }
+
+    public void saveLatestDrawNo(Long latestDrawNo) {
+        if (Objects.isNull(latestDrawNo)) {
+            log.error("Required values must not be null");
+            return;
+        }
+
+        valueOperations.set(CACHE_LATEST_DRAW_NO_KEY,  String.valueOf(latestDrawNo));
+        log.info("[RedisTemplateService saveLatestDrawNo() success] drawNo: {}", latestDrawNo);
+    }
+
+    public Long getLatestDrawNo() {
+        try {
+            return Long.valueOf(String.valueOf(valueOperations.get(CACHE_LATEST_DRAW_NO_KEY)));
+        } catch (Exception e) {
+            log.error("[RedisTemplateService getLatestDrawNo() failed]: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public void saveWinDetail(LottoResponse dto) {
+        if (Objects.isNull(dto) || Objects.isNull(dto.drawNo())) {
+            log.error("Required values must not be null");
+            return;
+        }
+
+        try {
+            //drawNo 를 hashKey 로 사용
+            hashOperations.put(CACHE_WIN_DETAIL_KEY, String.valueOf(dto.drawNo()), serializeResponseDto(dto));
+            log.info("[RedisTemplateService saveWinDetail() success] drawNo: {}", dto.drawNo());
+        } catch (Exception e) {
+            log.error("[RedisTemplateService saveWinDetail() failed]: {}", e.getMessage());
+        }
+    }
+
+    public LottoResponse getWinDetail(Long drawNo) {
+        try {
+            return deserializeResponseDto(hashOperations.get(CACHE_WIN_DETAIL_KEY, String.valueOf(drawNo)), LottoResponse.class);
+        } catch (Exception e) {
+            log.info("[RedisTemplateService getWinDetail() failed] drawNo: {}", drawNo);
+            return null;
+        }
+    }
+
+    public void saveShopDetail(ShopResponse dto) {
+        if (Objects.isNull(dto) || Objects.isNull(dto.id())) {
+            log.error("Required values must not be null");
+            return;
+        }
+
+        try {
+            //shopId 를 hashKey 로 사용
+            hashOperations.put(CACHE_SHOP_DETAIL_KEY, String.valueOf(dto.id()), serializeResponseDto(dto));
+            log.info("[RedisTemplateService saveShopDetail() success] shopId: {}", dto.id());
+        } catch (Exception e) {
+            log.error("[RedisTemplateService saveShopDetail() failed]: {}", e.getMessage());
+        }
+    }
+
+    public void deleteAllShopDetail() {
+        try {
+            redisTemplate.delete(CACHE_SHOP_DETAIL_KEY);
+            log.info("[RedisTemplateService deleteAllShopDetail() success]");
+        } catch (Exception e) {
+            log.error("[RedisTemplateService deleteAllShopDetail() failed]: {}", e.getMessage());
+        }
+    }
+
+    public ShopResponse getShopDetail(Long shopId) {
+        try {
+            return deserializeResponseDto(hashOperations.get(CACHE_SHOP_DETAIL_KEY, String.valueOf(shopId)), ShopResponse.class);
+        } catch (Exception e) {
+            log.info("[RedisTemplateService saveShopRanking() failed] shopId: {}", shopId);
+            return null;
+        }
+    }
+
+    public void saveShopRanking(Set<ShopResponse> shopResponses) {
+        int rank = 0;
+        for (ShopResponse dto : shopResponses) {
+            if (Objects.isNull(dto) || Objects.isNull(dto.id())) {
+                log.error("Required values must not be null");
+                return;
+            }
+
+            try {
+                //dto serialized 값을 value, treeSet 정렬 순서를 score 로 사용
+                zSetOperations.add(CACHE_SHOP_RANKING_KEY, serializeResponseDto(dto), rank++);
+                log.info("[RedisTemplateService saveShopRanking() success] rank: {}, shopId: {}", rank, dto.id());
+            } catch (Exception e) {
+                log.error("[RedisTemplateService saveShopRanking() failed]: {}", e.getMessage());
+            }
+        }
+    }
+
+    public void deleteALlShopRanking() {
+        try {
+            redisTemplate.delete(CACHE_SHOP_RANKING_KEY);
+            log.info("[RedisTemplateService deleteALlShopRanking() success]");
+        } catch (Exception e) {
+            log.error("[RedisTemplateService deleteALlShopRanking() failed]: {}", e.getMessage());
+        }
+    }
+
+    public Set<ShopResponse> getAllShopRanking() {
+        try {
+            return zSetOperations.range(CACHE_SHOP_RANKING_KEY, 0, 99).stream().map(o -> {
+                try {
+                    return deserializeResponseDto(o.toString(), ShopResponse.class);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }).collect(Collectors.toCollection(() ->
+                    new TreeSet<>(Comparator.comparing(ShopResponse::count1stWin)
+                            .thenComparing(ShopResponse::count1stWinAuto)
+                            .thenComparing(ShopResponse::count2ndWin).reversed()
+                            .thenComparing(ShopResponse::id))));
+        } catch (Exception e) {
+            log.info("[RedisTemplateService getAllShopRanking() failed]");
+            return Collections.emptySet();
+        }
+    }
+
+    private String serializeResponseDto(Object dto) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(dto);
+    }
+
+    private <T> T deserializeResponseDto(String serializedValue, Class<T> valueType) throws JsonProcessingException {
+        return objectMapper.readValue(serializedValue, valueType);
+    }
+}

--- a/src/test/groovy/com/example/projectlottery/redis/RedisTemplateTest.groovy
+++ b/src/test/groovy/com/example/projectlottery/redis/RedisTemplateTest.groovy
@@ -1,0 +1,58 @@
+package com.example.projectlottery.redis
+
+import com.example.projectlottery.IntegrationContainerBaseTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.core.RedisTemplate
+
+class RedisTemplateTest extends IntegrationContainerBaseTest {
+
+    @Autowired
+    private RedisTemplate redisTemplate
+
+    def "RedisTemplate - String operations"() {
+        given:
+        def valueOperations = redisTemplate.opsForValue()
+        def key = "key"
+        def value = "gp"
+
+        when:
+        valueOperations.set(key, value)
+
+        then:
+        def result = valueOperations.get(key)
+        result == value
+    }
+
+    def "RedisTemplate - Set operations"() {
+        given:
+        def setOperations = redisTemplate.opsForSet()
+        def key = "setKey"
+
+        when:
+        setOperations.add(key, "gp", "gp", "gp2", "gp3", "gp4")
+
+        then:
+        def size = setOperations.size(key)
+        size == 4
+    }
+
+    def "RedisTemplate - Hash operations"() {
+        given:
+        def hashOperations = redisTemplate.opsForHash()
+        def key = "hashKey"
+
+        when:
+        hashOperations.put(key, "subKey", "value")
+
+        then:
+        def result = hashOperations.get(key, "subKey")
+        result == "value"
+
+        def entries = hashOperations.entries(key)
+        entries.keySet().contains("subKey")
+        entries.values().contains("value")
+
+        def size = hashOperations.size(key)
+        size == entries.size()
+    }
+}


### PR DESCRIPTION
해당 작업은 redis cache 를 이용해 조회 성능 개선 관련 작업이다.

적용 대상은 변경이 거의 발생하지 않는 경우로 다음과 같이 선정했다.
1. 로또 회차별 추첨결과 - 이미 추첨한 회차 데이터 변경 X
2. 판매점 상세정보, 판매점 랭킹 - 매주 한 번 스크랩핑을 통한 갱신 외에는 데이터 변경 X

기존 response dto 에서 `Set` 을 사용하던 부분은 직렬화와 역직렬화를 거치며 순서가 보장이되지 않는 문제가 있어서 `List` 타입으로 변경해주었다.

This closes #49 