### PR TITLE
스크랩핑 Scheduling 적용

### DIFF
--- a/src/main/java/com/example/projectlottery/ProjectLotteryApplication.java
+++ b/src/main/java/com/example/projectlottery/ProjectLotteryApplication.java
@@ -3,7 +3,9 @@ package com.example.projectlottery;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class ProjectLotteryApplication {

--- a/src/main/java/com/example/projectlottery/api/ScrapScheduler.java
+++ b/src/main/java/com/example/projectlottery/api/ScrapScheduler.java
@@ -1,0 +1,60 @@
+package com.example.projectlottery.api;
+
+import com.example.projectlottery.api.service.ScrapLotteryShopService;
+import com.example.projectlottery.api.service.ScrapLotteryWinService;
+import com.example.projectlottery.api.service.ScrapLotteryWinShopService;
+import com.example.projectlottery.service.LottoService;
+import com.example.projectlottery.service.RedisTemplateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ScrapScheduler {
+
+    private final LottoService lottoService;
+
+    private final RedisTemplateService redisTemplateService;
+
+    private final ScrapLotteryShopService scrapLotteryShopService;
+    private final ScrapLotteryWinService scrapLotteryWinService;
+    private final ScrapLotteryWinShopService scrapLotteryWinShopService;
+
+    @Scheduled(cron = "0 0 3 * * SAT", zone = "Asia/Seoul") //매주 토요일 3시에 실행 (로또 6/45 판매점)
+    public void scrapShopL645() {
+        log.info("=== Started scrapShopL645() : {}", LocalDateTime.now());
+
+        try {
+            String scrapState = "ALL";
+            scrapLotteryShopService.getShopL645(scrapState);
+        } catch (Exception e) {
+            log.error("=== Failed scrapShopL645() : {}", LocalDateTime.now());
+        } finally {
+            redisTemplateService.deleteAllShopDetail(); //redis cache 삭제 -> 신규 또는 판매중지 판매점 변동되므로
+        }
+
+        log.info("=== Success scrapShopL645() : {}", LocalDateTime.now());
+    }
+
+    @Scheduled(cron = "0 0 22 * * SAT", zone = "Asia/Seoul") //매주 토요일 22시에 실행 (로또 6/45 추첨 결과)
+    public void scrapWinL645() {
+        log.info("=== Started scrapWinL645() : {}", LocalDateTime.now());
+
+        try {
+            Long drawNo = lottoService.getLatestDrawNo() + 1;
+            scrapLotteryWinService.getResultsL645(drawNo, drawNo);
+            scrapLotteryWinShopService.getWinShopL645(drawNo, drawNo);
+        } catch (Exception e) {
+            log.error("=== Failed scrapWinL645() : {}", LocalDateTime.now());
+        } finally {
+            redisTemplateService.deleteALlShopRanking(); //redis cache 삭제 -> 랭킹은 일주일마다 변동되므로
+        }
+
+        log.info("=== Success scrapWinL645() : {}", LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
해당 pr 은 일정 주기마다 자동으로 스크랩핑을 수행하도록 하는 자동화 관련 작업이다.

동행복권 사이트에서 로또 추첨결과 혹은 판매점 정보를 주기적으로 스크랩핑을 해 와야 한다.
기존에는 매주 토요일에 수동으로 작업했지만, schduling 적용을 통해 일정 주기로 자동 실행되도록 했다.

This closes #51 