### PR TITLE
application.yaml - hibernate 설정 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,8 +13,14 @@ spring:
   config:
     activate:
       on-profile: common
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
 
 kakao:
+  js:
+    key: ${KAKAO_JAVA_SCRIPT_KEY}
   rest:
     api:
       key: ${KAKAO_REST_API_KEY}
@@ -36,7 +42,7 @@ spring:
       port: 6379
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
@@ -44,7 +50,7 @@ spring:
     defer-datasource-initialization: true
   sql:
     init:
-      mode: always
+      mode: never
 
 ---
 


### PR DESCRIPTION
해당 pr 은 db 데이터가 유실되지 않도록 hibernate 초기화 관련 옵션을 변경하는 작업이다.

1. `default_batch_fetch_size` = 100
2. `jpa.hibernate.ddl-auto1 = validate
3. `sql.init.mode`= never

초기 개발 시, 편의를 위해 활성화 했었지만, 데이터 및 테이블 초기화가 발생하지 않도록 off 한다.

This closes #56 