### PR TITLE
selenium, chromedriver 관련 옵션 수정

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -27,6 +27,7 @@ services:
     build:
       dockerfile: Dockerfile
       context: ./selenium
+    image: pyo92/project-lottery-selenium
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2g

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -27,9 +27,10 @@ services:                                                  # 실행하려는 컨
     build:
       dockerfile: Dockerfile
       context: ./selenium
+    image: pyo92/project-lottery-selenium
     volumes:
       - /dev/shm:/dev/shm
-    shm_size: 2g
+    shm_size: 256mb
     environment:
       - SE_SCREEN_WIDTH=1920
       - SE_SCREEN_HEIGHT=768

--- a/src/main/java/com/example/projectlottery/api/service/ChromeDriverService.java
+++ b/src/main/java/com/example/projectlottery/api/service/ChromeDriverService.java
@@ -28,6 +28,10 @@ public class ChromeDriverService {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--start-maximized");
         options.addArguments("--window-size=1920,1080");
+        options.addArguments("--headless");
+        options.addArguments("--no-sandbox");
+        options.addArguments("--disable-gpu");
+        options.addArguments("--disable-dev-shm-usage");
 
         try {
             webDriver = new RemoteWebDriver(new URL(SELENIUM_HUB_URL), options);


### PR DESCRIPTION
이번 pr 은 AWS EC2 T2.micro 환경에서 스크랩핑 서비스 동작 시 서버가 죽어버리는 현상을 조치하기 위한 안정화 옵션 설정 관련 작업이다.

AWS EC2 인스턴스는 T2.micro 로 설정되어 있고 ram 용량은 1gb 에 불과하다.
그래서 swap 메모리로 2gb 를 증설했다. (이전에 hdd 용량을 30gb 로 설정했던 덕분)

selenium `shm_size` 를 비롯해 chromedriver 안정성 관련 옵션을 추가헀다.

This closes #69 