### PR TITLE
[고도화] 2등 당첨 판매점 스크랩 오류 수정

### DIFF
--- a/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinShopService.java
+++ b/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinShopService.java
@@ -91,7 +91,17 @@ public class ScrapLotteryWinShopService {
      */
     private void getWinShopL645_2nd(long drawNo) {
         String css = "#page_box > a";
+
         int pageCount = chromeDriverService.getElementsByCssSelector(css).size();
+        System.out.println("pageCount = " + pageCount);
+
+        //20230406 - 2등 당첨내역 scrap 오류 수정
+        if (chromeDriverService.getElementsByCssSelector(css).size() > 10) {
+            pageCount = Integer.parseInt(chromeDriverService
+                    .getElementsByCssSelector("#page_box > a.go.end").get(0)
+                    .getAttribute("onclick")
+                    .replaceAll("[^0-9]", ""));
+        }
 
         for (int i = 1; i <= pageCount; i++) {
             setSelectDrawNo(drawNo);


### PR DESCRIPTION
개발 당시에는 존재하지 않았던 케이스라서 오류가 발생하는 것을 인지하지 못했다.
약 600명정도 나온 비정상적인 케이스인 1057 회차에서 오류를 발견하고, 급히 조치한다.

2등 당첨 판매점이 최대 10페이지까지 스크랩되고 있어서 이를 수정했다.

This closes #84 