### PR TITLE
[고도화] 복권판매점 상세 - 당첨집계 정보 오류 수정

### DIFF
--- a/src/main/java/com/example/projectlottery/dto/response/ShopResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/ShopResponse.java
@@ -41,43 +41,7 @@ public record ShopResponse(
                 count2ndWin, amountSum2ndWin, amountMax2ndWin, amountMin2ndWin, lotto1stWin, lotto2ndWin);
     }
 
-    public static ShopResponse from(Shop entity, QShopWinSummary QShopWinSummary, List<QLottoSummary> r1, List<QLottoSummary> r2) {
-//        List<LottoWinShop> lotto1stWinShops = entity.getLottoWinShops().stream()
-//                .filter(lottoWinShop -> lottoWinShop.getRank() == 1)
-//                .toList();
-//        long count1stWinAuto = lotto1stWinShops.stream()
-//                .filter(lottoWinShop -> lottoWinShop.getLottoPurchaseType() == LottoPurchaseType.AUTO)
-//                .count();
-//        long count1stWinManual = lotto1stWinShops.stream()
-//                .filter(lottoWinShop -> lottoWinShop.getLottoPurchaseType() != LottoPurchaseType.AUTO)
-//                .count();
-//        long count1stWin = count1stWinAuto + count1stWinManual;
-//
-//        List<Long> lotto1stWinAmounts = lotto1stWinShops.stream()
-//                .map(lottoWinShop -> lottoWinShop.getLotto().getLottoPrizes().stream()
-//                        .filter(lottoPrize -> lottoPrize.getRank() == 1)
-//                        .mapToLong(LottoPrize::getWinAmountPerGame)
-//                        .sum())
-//                .toList();
-//        long amountSum1stWin = lotto1stWinAmounts.stream().mapToLong(value -> value).sum();
-//        long amountMax1stWin = lotto1stWinAmounts.stream().mapToLong(value -> value).max().orElse(0L);
-//        long amountMin1stWin = lotto1stWinAmounts.stream().mapToLong(value -> value).min().orElse(0L);
-//
-//        List<LottoWinShop> lotto2ndWinShops = entity.getLottoWinShops().stream()
-//                .filter(lottoWinShop -> lottoWinShop.getRank() == 2)
-//                .toList();
-//        long count2ndWin = lotto2ndWinShops.stream().count();
-//
-//        List<Long> lotto2ndWinAmounts = lotto2ndWinShops.stream()
-//                .map(lottoWinShop -> lottoWinShop.getLotto().getLottoPrizes().stream()
-//                        .filter(lottoPrize -> lottoPrize.getRank() == 2)
-//                        .mapToLong(LottoPrize::getWinAmountPerGame)
-//                        .sum())
-//                .toList();
-//        long amountSum2ndWin = lotto2ndWinAmounts.stream().mapToLong(value -> value).sum();
-//        long amountMax2ndWin = lotto2ndWinAmounts.stream().mapToLong(value -> value).max().orElse(0L);
-//        long amountMin2ndWin = lotto2ndWinAmounts.stream().mapToLong(value -> value).min().orElse(0L);
-
+    public static ShopResponse from(Shop entity, QShopWinSummary QShopWinSummary, List<QLottoSummary> winSummary1, List<QLottoSummary> winSummary2) {
         return ShopResponse.of(
                 entity.getId(),
                 entity.getName(),
@@ -98,8 +62,8 @@ public record ShopResponse(
                 QShopWinSummary.amountSum2ndWin(),
                 QShopWinSummary.amountMax2ndWin(),
                 QShopWinSummary.amountMin2ndWin(),
-                r1,
-                r2
+                winSummary1,
+                winSummary2
         );
     }
 }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
@@ -117,7 +117,7 @@ public class ShopRepositoryCustomImpl extends QuerydslRepositorySupport implemen
 
         query.orderBy(new OrderSpecifier<>(Order.DESC, Expressions.constant(4L))); //1등.DESC
         query.orderBy(new OrderSpecifier<>(Order.DESC, Expressions.constant(5L))); //2등.DESC
-        query.orderBy(new OrderSpecifier<>(Order.ASC, Expressions.constant(2L))); //name.ASC
+        query.orderBy(new OrderSpecifier<>(Order.ASC, Expressions.constant(1L))); //id.ASC
 
         return query.fetch();
     }
@@ -127,26 +127,26 @@ public class ShopRepositoryCustomImpl extends QuerydslRepositorySupport implemen
      */
     @Override
     public QShopWinSummary getShopWinSummaryResponseForShopDetail(Long shopId) {
-        QShopWinSummary fetch = from(lottoWinShop)
-                .innerJoin(lottoPrize)
-                .on(lottoWinShop.lotto.eq(lottoPrize.lotto), lottoWinShop.rank.eq(lottoPrize.rank))
-                .where(lottoWinShop.shop.id.eq(shopId), lottoWinShop.rank.in(1, 2))
-                .groupBy(lottoWinShop.shop.id)
+        //오류수정
+        return from(shop)
+                .leftJoin(lottoWinShop)
+                    .on(shop.eq(lottoWinShop.shop), lottoWinShop.rank.in(1, 2))
+                .leftJoin(lottoPrize)
+                    .on(lottoWinShop.lotto.eq(lottoPrize.lotto), lottoWinShop.rank.eq(lottoPrize.rank))
+                .where(shop.id.eq(shopId))
+                .groupBy(shop.id)
                 .select(Projections.constructor(QShopWinSummary.class,
-                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(1).otherwise(0).sum(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(1).and(lottoWinShop.lottoPurchaseType.eq(LottoPurchaseType.AUTO))).then(1).otherwise(0).sum(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(1).and(lottoWinShop.lottoPurchaseType.ne(LottoPurchaseType.AUTO))).then(1).otherwise(0).sum(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).sum(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).max(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).min(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(1).otherwise(0).sum(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).sum(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).max(),
-                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).min()))
-                .fetch()
-                .get(0);
-
-        return fetch;
+                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(1).otherwise(0).sum().coalesce(0),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(1).and(lottoWinShop.lottoPurchaseType.eq(LottoPurchaseType.AUTO))).then(1).otherwise(0).sum().coalesce(0),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(1).and(lottoWinShop.lottoPurchaseType.ne(LottoPurchaseType.AUTO))).then(1).otherwise(0).sum().coalesce(0),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).sum().coalesce(0L),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).max().coalesce(0L),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(1)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).min().coalesce(0L),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(1).otherwise(0).sum().coalesce(0),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).sum().coalesce(0L),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).max().coalesce(0L),
+                        new CaseBuilder().when(lottoWinShop.rank.eq(2)).then(lottoPrize.winAmountPerGame).otherwise(Expressions.nullExpression()).min().coalesce(0L)))
+                .fetch().get(0);
     }
 
     /**

--- a/src/main/java/com/example/projectlottery/service/ShopService.java
+++ b/src/main/java/com/example/projectlottery/service/ShopService.java
@@ -54,12 +54,12 @@ public class ShopService {
             Optional<Shop> shopById = shopRepository.findById(id);
 
             if (shopById.isPresent()) {
-                QShopWinSummary QShopWinSummary = shopRepository.getShopWinSummaryResponseForShopDetail(id);
+                QShopWinSummary qShopWinSummaries = shopRepository.getShopWinSummaryResponseForShopDetail(id);
 
-                List<QLottoSummary> qLottoSummary = shopRepository.getLottoSummaryResponseForShopDetail(id, 1);
-                List<QLottoSummary> qLottoSummary1 = shopRepository.getLottoSummaryResponseForShopDetail(id, 2);
+                List<QLottoSummary> qLottoSummary1stWin = shopRepository.getLottoSummaryResponseForShopDetail(id, 1);
+                List<QLottoSummary> qLottoSummary2ndWin = shopRepository.getLottoSummaryResponseForShopDetail(id, 2);
 
-                shopResponse = ShopResponse.from(shopById.get(), QShopWinSummary, qLottoSummary, qLottoSummary1);
+                shopResponse = ShopResponse.from(shopById.get(), qShopWinSummaries, qLottoSummary1stWin, qLottoSummary2ndWin);
 
             } else {
                 throw new EntityNotFoundException("해당 판매점 없습니다. (id: " + id + ")");


### PR DESCRIPTION
from(`lotto_win_shop`) 테이블로 시작하기에 한 번도 당첨된 적이 없는 판매점의 경우 오류가 발생한다.
조회된 행이 0개이기 때문에 fetch().get(0) 에서 문제가 되는 것이다.

무조건, `하나의 행이 조회`되어야 하므로 from(`shop`) 부터 시작하게 수정했다.
그리고 기본 값으로 집계 데이터를 세팅하기 위해 coalesce 처리해 0으로 반환할 수 있도록 조치했다.

This closes #94 