### PR TITLE
로또 분석 페이지 개발

### DIFF
--- a/src/main/java/com/example/projectlottery/controller/LottoController.java
+++ b/src/main/java/com/example/projectlottery/controller/LottoController.java
@@ -6,6 +6,7 @@ import com.example.projectlottery.dto.request.UserCombinationRequest;
 import com.example.projectlottery.dto.response.LottoGameResponse;
 import com.example.projectlottery.dto.response.LottoResponse;
 import com.example.projectlottery.dto.response.UserCombinationResponse;
+import com.example.projectlottery.dto.response.analysis.*;
 import com.example.projectlottery.service.LottoService;
 import com.example.projectlottery.service.UserCombinationService;
 import lombok.RequiredArgsConstructor;
@@ -208,5 +209,113 @@ public class LottoController {
         ));
 
         return LottoGameResponse.of(gameSet);
+    }
+
+    /**
+     * 로또 분석 - 회차별 AC 통계 post 처리
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 분석 - 회차별 AC 통계 response dto
+     */
+    @ResponseBody
+    @PostMapping("/analysis/number-arithmetic-complexity")
+    public List<NumberAcAnalysisResponse> lottoNumberAcAnalysis(Long startDrawNo, Long endDrawNo) {
+        Long latestDrawNo = lottoService.getLatestDrawNo();
+        if (startDrawNo == null || startDrawNo < 1L || startDrawNo > latestDrawNo) {
+            startDrawNo = 1L;
+        }
+
+        if (endDrawNo == null || endDrawNo < 1L || endDrawNo > latestDrawNo) {
+            endDrawNo = latestDrawNo;
+        }
+
+        return lottoService.getLottoNumberAcAnalysis(startDrawNo, endDrawNo);
+    }
+
+    /**
+     * 로또 분석 - 회차별 총합 통계 post 처리
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 분석 - 회차별 총합 통계 response dto
+     */
+    @ResponseBody
+    @PostMapping("/analysis/number-sum")
+    public List<NumberSumAnalysisResponse> lottoNumberSumAnalysis(Long startDrawNo, Long endDrawNo) {
+        Long latestDrawNo = lottoService.getLatestDrawNo();
+        if (startDrawNo == null || startDrawNo < 1L || startDrawNo > latestDrawNo) {
+            startDrawNo = 1L;
+        }
+
+        if (endDrawNo == null || endDrawNo < 1L || endDrawNo > latestDrawNo) {
+            endDrawNo = latestDrawNo;
+        }
+
+        return lottoService.getLottoNumberSumAnalysis(startDrawNo, endDrawNo);
+    }
+
+    /**
+     * 로또 분석 - 번호별 출현 횟수 post 처리
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 분석 - 번호별 출현 횟수 response dto
+     */
+    @ResponseBody
+    @PostMapping("/analysis/number-hit-count")
+    public List<NumberHitCountWithBonusAnalysisResponse> lottoNumberHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        Long latestDrawNo = lottoService.getLatestDrawNo();
+        if (startDrawNo == null || startDrawNo < 1L || startDrawNo > latestDrawNo) {
+            startDrawNo = 1L;
+        }
+
+        if (endDrawNo == null || endDrawNo < 1L || endDrawNo > latestDrawNo) {
+            endDrawNo = latestDrawNo;
+        }
+
+        return lottoService.getLottoNumberHitCountAnalysis(startDrawNo, endDrawNo, bonus);
+    }
+
+    /**
+     * 로또 분석 - 번호 대역별 색상 통계 post 처리
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 분석 - 번호별 색상 통계 response dto
+     */
+    @ResponseBody
+    @PostMapping("/analysis/number-range-hit-count")
+    public List<NumberRangeHitCountAnalysisResponse> lottoNumberRangeHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        Long latestDrawNo = lottoService.getLatestDrawNo();
+        if (startDrawNo == null || startDrawNo < 1L || startDrawNo > latestDrawNo) {
+            startDrawNo = 1L;
+        }
+
+        if (endDrawNo == null || endDrawNo < 1L || endDrawNo > latestDrawNo) {
+            endDrawNo = latestDrawNo;
+        }
+
+        return lottoService.getLottoNumberRangeHitCountAnalysis(startDrawNo, endDrawNo, bonus);
+    }
+
+    /**
+     * 로또 분석 - 번호별 미출현 기간 post 처리
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 분석 - 번호별 미출현 기간 response dto
+     */
+    @ResponseBody
+    @PostMapping("/analysis/number-miss-count")
+    public List<NumberMissCountAnalysisResponse> lottoNumberMissCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        Long latestDrawNo = lottoService.getLatestDrawNo();
+        if (startDrawNo == null || startDrawNo < 1L || startDrawNo > latestDrawNo) {
+            startDrawNo = 1L;
+        }
+
+        if (endDrawNo == null || endDrawNo < 1L || endDrawNo > latestDrawNo) {
+            endDrawNo = latestDrawNo;
+        }
+
+        return lottoService.getLottoNumberMissCountAnalysis(startDrawNo, endDrawNo, bonus);
     }
 }

--- a/src/main/java/com/example/projectlottery/dto/response/analysis/NumberAcAnalysisResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/analysis/NumberAcAnalysisResponse.java
@@ -1,0 +1,17 @@
+package com.example.projectlottery.dto.response.analysis;
+
+public record NumberAcAnalysisResponse(
+        Long drawNo,
+        Integer number1,
+        Integer number2,
+        Integer number3,
+        Integer number4,
+        Integer number5,
+        Integer number6,
+        Integer ac
+) {
+
+    public static NumberAcAnalysisResponse of(Long drawNo, Integer number1, Integer number2, Integer number3, Integer number4, Integer number5, Integer number6, Integer ac) {
+        return new NumberAcAnalysisResponse(drawNo, number1, number2, number3, number4, number5, number6, ac);
+    }
+}

--- a/src/main/java/com/example/projectlottery/dto/response/analysis/NumberHitCountAnalysisResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/analysis/NumberHitCountAnalysisResponse.java
@@ -1,0 +1,12 @@
+package com.example.projectlottery.dto.response.analysis;
+
+public record NumberHitCountAnalysisResponse(
+        Integer number,
+        Long count
+) {
+
+    public static NumberHitCountAnalysisResponse of(Integer number, Long count) {
+        return new NumberHitCountAnalysisResponse(number, count);
+    }
+}
+

--- a/src/main/java/com/example/projectlottery/dto/response/analysis/NumberHitCountWithBonusAnalysisResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/analysis/NumberHitCountWithBonusAnalysisResponse.java
@@ -1,0 +1,12 @@
+package com.example.projectlottery.dto.response.analysis;
+
+public record NumberHitCountWithBonusAnalysisResponse(
+        Integer number,
+        Long count,
+        Long bonus
+) {
+
+    public static NumberHitCountWithBonusAnalysisResponse of(Integer number, Long count, Long bonus) {
+        return new NumberHitCountWithBonusAnalysisResponse(number, count, bonus);
+    }
+}

--- a/src/main/java/com/example/projectlottery/dto/response/analysis/NumberMissCountAnalysisResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/analysis/NumberMissCountAnalysisResponse.java
@@ -1,0 +1,12 @@
+package com.example.projectlottery.dto.response.analysis;
+
+public record NumberMissCountAnalysisResponse(
+        Integer number,
+        Long count,
+        Long bonus
+) {
+
+    public static NumberMissCountAnalysisResponse of(Integer number, Long count, Long bonus) {
+        return new NumberMissCountAnalysisResponse(number, count, bonus);
+    }
+}

--- a/src/main/java/com/example/projectlottery/dto/response/analysis/NumberRangeHitCountAnalysisResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/analysis/NumberRangeHitCountAnalysisResponse.java
@@ -1,0 +1,12 @@
+package com.example.projectlottery.dto.response.analysis;
+
+public record NumberRangeHitCountAnalysisResponse(
+        Integer numberRange,
+        Long count,
+        Long bonus
+) {
+
+    public static NumberRangeHitCountAnalysisResponse of(Integer numberRange, Long count, Long bonus) {
+        return new NumberRangeHitCountAnalysisResponse(numberRange, count, bonus);
+    }
+}

--- a/src/main/java/com/example/projectlottery/dto/response/analysis/NumberSumAnalysisResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/analysis/NumberSumAnalysisResponse.java
@@ -1,0 +1,17 @@
+package com.example.projectlottery.dto.response.analysis;
+
+public record NumberSumAnalysisResponse(
+        Long drawNo,
+        Integer number1,
+        Integer number2,
+        Integer number3,
+        Integer number4,
+        Integer number5,
+        Integer number6,
+        Integer sum
+) {
+
+    public static NumberSumAnalysisResponse of(Long drawNo, Integer number1, Integer number2, Integer number3, Integer number4, Integer number5, Integer number6, Integer sum) {
+        return new NumberSumAnalysisResponse(drawNo, number1, number2, number3, number4, number5, number6, sum);
+    }
+}

--- a/src/main/java/com/example/projectlottery/repository/LottoRepository.java
+++ b/src/main/java/com/example/projectlottery/repository/LottoRepository.java
@@ -9,7 +9,7 @@ public interface LottoRepository extends JpaRepository<Lotto, Long>, LottoReposi
 
     /**
      * 가장 최근 회차 번호 조회 (for 로또추첨결과 페이지 회차 selector 생성용)
-     * @return
+     * @return 최근 회차
      */
     @Query("select max(l.drawNo) from Lotto l")
     Long getLatestDrawNo();

--- a/src/main/java/com/example/projectlottery/repository/querydsl/LottoRepositoryCustom.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/LottoRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.repository.querydsl;
 
+import com.example.projectlottery.dto.response.analysis.*;
 import com.example.projectlottery.dto.response.querydsl.QShopSummary;
 
 import java.util.List;
@@ -13,4 +14,48 @@ public interface LottoRepositoryCustom {
      * @return 1, 2등 배출 목록
      */
     List<QShopSummary> getShopSummaryResponseForLotto(Long drawNo, Integer rank);
+
+    /**
+     * 로또 회차별 당첨번호 AC 분석 (for querydsl)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 회차별 당첨번호 AC 통계
+     */
+    List<NumberAcAnalysisResponse> getLottoNumberAcAnalysis(Long startDrawNo, Long endDrawNo);
+
+    /**
+     * 로또 회차별 당첨번호 총합 분석 (for querydsl)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 회차별 당첨번호 AC 통계
+     */
+    List<NumberSumAnalysisResponse> getLottoNumberSumAnalysis(Long startDrawNo, Long endDrawNo);
+
+    /**
+     * 로또 번호 출현 횟수 분석 (for querydsl)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 번호 출현 횟수
+     */
+    List<NumberHitCountWithBonusAnalysisResponse> getLottoNumberHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus);
+
+    /**
+     * 로또 번호 대역별 색상 통계 분석 (for querydsl)
+     *
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 대역별 색상 통계
+     */
+    List<NumberRangeHitCountAnalysisResponse> getLottoNumberRangeHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus);
+
+    /**
+     * 로또 번호 미출현 기간 분석 (for querydsl)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 번호 미출현 기간
+     */
+    List<NumberMissCountAnalysisResponse> getLottoNumberMissCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus);
 }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/LottoRepositoryCustomImpl.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/LottoRepositoryCustomImpl.java
@@ -1,30 +1,38 @@
 package com.example.projectlottery.repository.querydsl;
 
 import com.example.projectlottery.domain.Lotto;
+import com.example.projectlottery.domain.QLotto;
 import com.example.projectlottery.domain.QLottoWinShop;
 import com.example.projectlottery.domain.type.LottoPurchaseType;
+import com.example.projectlottery.dto.response.analysis.*;
 import com.example.projectlottery.dto.response.querydsl.QShopSummary;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.JPAExpressions;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class LottoRepositoryCustomImpl extends QuerydslRepositorySupport implements LottoRepositoryCustom {
 
-    private QLottoWinShop lottoWinShop;
-    private QLottoWinShop lottoWinShopForCounting;
+    private final QLotto lotto;
+    private final QLottoWinShop lottoWinShop;
+    private final QLottoWinShop lottoWinShopForCounting;
 
     public LottoRepositoryCustomImpl() {
         super(Lotto.class);
 
+        lotto = QLotto.lotto;
         lottoWinShop = QLottoWinShop.lottoWinShop;
         lottoWinShopForCounting = new QLottoWinShop("new"); //같은 entity 를 join 하기 위해 추가 생성 (집계)
     }
 
     /**
      * 로또추첨결과 - 1, 2등 배출 목록 조회 (for querydsl)
+     *
      * @param drawNo 회차 번호
      * @param rank 등위
      * @return 1, 2등 배출 목록
@@ -49,5 +57,329 @@ public class LottoRepositoryCustomImpl extends QuerydslRepositorySupport impleme
                                 .where(lottoWinShopForCounting.shop.id.eq(lottoWinShop.shop.id), lottoWinShopForCounting.rank.eq(2))))
                 .orderBy(lottoWinShop.no.asc())
                 .fetch();
+    }
+
+    /**
+     * 로또 회차별 당첨번호 AC 분석 (for querydsl)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 회차별 당첨번호 AC 통계
+     */
+    @Override
+    public List<NumberAcAnalysisResponse> getLottoNumberAcAnalysis(Long startDrawNo, Long endDrawNo) {
+        List<Tuple> subQuery = from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(lotto.drawNo,
+                        lotto.lottoWinNumber.number1,
+                        lotto.lottoWinNumber.number2,
+                        lotto.lottoWinNumber.number3,
+                        lotto.lottoWinNumber.number4,
+                        lotto.lottoWinNumber.number5,
+                        lotto.lottoWinNumber.number6)
+                .orderBy(lotto.drawNo.desc())
+                .fetch();
+
+        List<NumberAcAnalysisResponse> result = new ArrayList<>();
+
+        subQuery.forEach(r -> {
+            Set<Integer> diff = new HashSet<>();
+
+            for (int i = 1; i < 7; i++) {
+                for (int j = i + 1; j < 7; j++) {
+                    diff.add(Math.abs(r.get(i, Integer.class) - r.get(j, Integer.class)));
+                }
+            }
+
+            result.add(NumberAcAnalysisResponse.of(
+                    r.get(0, Long.class),
+                    r.get(1, Integer.class),
+                    r.get(2, Integer.class),
+                    r.get(3, Integer.class),
+                    r.get(4, Integer.class),
+                    r.get(5, Integer.class),
+                    r.get(6, Integer.class),
+                    diff.size() - 5));
+        });
+
+        return result;
+    }
+
+    /**
+     * 로또 회차별 당첨번호 총합 분석 (for querydsl)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 회차별 당첨번호 총합 통계
+     */
+    @Override
+    public List<NumberSumAnalysisResponse> getLottoNumberSumAnalysis(Long startDrawNo, Long endDrawNo) {
+        List<Tuple> subQuery = from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(lotto.drawNo,
+                        lotto.lottoWinNumber.number1,
+                        lotto.lottoWinNumber.number2,
+                        lotto.lottoWinNumber.number3,
+                        lotto.lottoWinNumber.number4,
+                        lotto.lottoWinNumber.number5,
+                        lotto.lottoWinNumber.number6)
+                .orderBy(lotto.drawNo.desc())
+                .fetch();
+
+        List<NumberSumAnalysisResponse> result = new ArrayList<>();
+
+        subQuery.forEach(r -> {
+            result.add(NumberSumAnalysisResponse.of(
+                    r.get(0, Long.class),
+                    r.get(1, Integer.class),
+                    r.get(2, Integer.class),
+                    r.get(3, Integer.class),
+                    r.get(4, Integer.class),
+                    r.get(5, Integer.class),
+                    r.get(6, Integer.class),
+                    (r.get(1, Integer.class) +
+                            r.get(2, Integer.class) +
+                            r.get(3, Integer.class) +
+                            r.get(4, Integer.class) +
+                            r.get(5, Integer.class) +
+                            r.get(6, Integer.class))));
+        });
+
+        return result;
+    }
+
+    /**
+     * 로또 번호 출현 횟수 분석 (for querydsl)
+     *
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 번호 출현 횟수
+     */
+    @Override
+    public List<NumberHitCountWithBonusAnalysisResponse> getLottoNumberHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        Map<Integer, Long> numberCount = new HashMap<>();
+        Map<Integer, Long> bonusCount = new HashMap<>();
+
+        //추첨 결과 번호 1~6 까지 모든 번호에 대해 출현 통계를 만든다.
+        from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(Projections.constructor(NumberHitCountAnalysisResponse.class,
+                        lotto.lottoWinNumber.number1,
+                        lotto.lottoWinNumber.number1.count()))
+                .groupBy(lotto.lottoWinNumber.number1)
+                .fetch()
+                .forEach(r -> {
+                    if (numberCount.containsKey(r.number())) {
+                        numberCount.put(r.number(), numberCount.get(r.number()) + r.count());
+                    } else {
+                        numberCount.put(r.number(), r.count());
+                    }
+                });
+        from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(Projections.constructor(NumberHitCountAnalysisResponse.class,
+                        lotto.lottoWinNumber.number2,
+                        lotto.lottoWinNumber.number2.count()))
+                .groupBy(lotto.lottoWinNumber.number2)
+                .fetch()
+                .forEach(r -> {
+                    if (numberCount.containsKey(r.number())) {
+                        numberCount.put(r.number(), numberCount.get(r.number()) + r.count());
+                    } else {
+                        numberCount.put(r.number(), r.count());
+                    }
+                });
+        from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(Projections.constructor(NumberHitCountAnalysisResponse.class,
+                        lotto.lottoWinNumber.number3,
+                        lotto.lottoWinNumber.number3.count()))
+                .groupBy(lotto.lottoWinNumber.number3)
+                .fetch()
+                .forEach(r -> {
+                    if (numberCount.containsKey(r.number())) {
+                        numberCount.put(r.number(), numberCount.get(r.number()) + r.count());
+                    } else {
+                        numberCount.put(r.number(), r.count());
+                    }
+                });
+        from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(Projections.constructor(NumberHitCountAnalysisResponse.class,
+                        lotto.lottoWinNumber.number4,
+                        lotto.lottoWinNumber.number4.count()))
+                .groupBy(lotto.lottoWinNumber.number4)
+                .fetch()
+                .forEach(r -> {
+                    if (numberCount.containsKey(r.number())) {
+                        numberCount.put(r.number(), numberCount.get(r.number()) + r.count());
+                    } else {
+                        numberCount.put(r.number(), r.count());
+                    }
+                });
+        from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(Projections.constructor(NumberHitCountAnalysisResponse.class,
+                        lotto.lottoWinNumber.number5,
+                        lotto.lottoWinNumber.number5.count()))
+                .groupBy(lotto.lottoWinNumber.number5)
+                .fetch()
+                .forEach(r -> {
+                    if (numberCount.containsKey(r.number())) {
+                        numberCount.put(r.number(), numberCount.get(r.number()) + r.count());
+                    } else {
+                        numberCount.put(r.number(), r.count());
+                    }
+                });
+        from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                .select(Projections.constructor(NumberHitCountAnalysisResponse.class,
+                        lotto.lottoWinNumber.number6,
+                        lotto.lottoWinNumber.number6.count()))
+                .groupBy(lotto.lottoWinNumber.number6)
+                .fetch()
+                .forEach(r -> {
+                    if (numberCount.containsKey(r.number())) {
+                        numberCount.put(r.number(), numberCount.get(r.number()) + r.count());
+                    } else {
+                        numberCount.put(r.number(), r.count());
+                    }
+                });
+
+        //bonus 번호 포함 여부에 따라 출현 통계를 추가한다.
+        if (bonus) {
+            from(lotto)
+                .where(lotto.drawNo.between(startDrawNo, endDrawNo))
+                    .select(Projections.constructor(NumberHitCountAnalysisResponse.class,
+                            lotto.lottoWinNumber.numberB,
+                            lotto.lottoWinNumber.numberB.count()))
+                    .groupBy(lotto.lottoWinNumber.numberB)
+                    .fetch()
+                    .forEach(r -> {
+                        if (bonusCount.containsKey(r.number())) {
+                            bonusCount.put(r.number(), bonusCount.get(r.number()) + r.count());
+                        } else {
+                            bonusCount.put(r.number(), r.count());
+                        }
+                    });
+        }
+
+        List<NumberHitCountWithBonusAnalysisResponse> result = new ArrayList<>();
+        for (int i = 1; i <= 45; i++) {
+            Long nc = numberCount.containsKey(i) ? numberCount.get(i) : 0;
+            Long bc = bonusCount.containsKey(i) ? bonusCount.get(i) : 0;
+            result.add(NumberHitCountWithBonusAnalysisResponse.of(i, nc, bc));
+        }
+
+        result.sort(Comparator.comparing(NumberHitCountWithBonusAnalysisResponse::number)); //default sort
+
+        return result;
+    }
+
+    /**
+     * 로또 번호 대역별 색상 통계 분석 (for querydsl)
+     *
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 대역별 색상 통계
+     */
+    @Override
+    public List<NumberRangeHitCountAnalysisResponse> getLottoNumberRangeHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        List<NumberHitCountWithBonusAnalysisResponse> lottoNumberHitCountAnalysis = getLottoNumberHitCountAnalysis(startDrawNo, endDrawNo, bonus);
+
+        long cnt0 = 0;
+        long cnt1 = 0;
+        long cnt2 = 0;
+        long cnt3 = 0;
+        long cnt4 = 0;
+        
+        long bonusCnt0 = 0;
+        long bonusCnt1 = 0;
+        long bonusCnt2 = 0;
+        long bonusCnt3 = 0;
+        long bonusCnt4 = 0;
+
+        for (NumberHitCountWithBonusAnalysisResponse r : lottoNumberHitCountAnalysis) {
+            int number = r.number();
+            long count = r.count();
+            long bonusCount = r.bonus();
+
+            if (number <= 10) {
+                cnt0 += count;
+                bonusCnt0 += bonusCount;
+            } else if (number <= 20) {
+                cnt1 += count;
+                bonusCnt1 += bonusCount;
+            } else if (number <= 30) {
+                cnt2 += count;
+                bonusCnt2 += bonusCount;
+            } else if (number <= 40) {
+                cnt3 += count;
+                bonusCnt3 += bonusCount;
+            } else {
+                cnt4 += count;
+                bonusCnt4 += bonusCount;
+            }
+        }
+
+        List<NumberRangeHitCountAnalysisResponse> result = new ArrayList<>();
+        result.add(NumberRangeHitCountAnalysisResponse.of(10, cnt0, bonusCnt0));
+        result.add(NumberRangeHitCountAnalysisResponse.of(20, cnt1, bonusCnt1));
+        result.add(NumberRangeHitCountAnalysisResponse.of(30, cnt2, bonusCnt2));
+        result.add(NumberRangeHitCountAnalysisResponse.of(40, cnt3, bonusCnt3));
+        result.add(NumberRangeHitCountAnalysisResponse.of(45, cnt4, bonusCnt4));
+
+        return result;
+    }
+
+    /**
+     * 로또 번호 미출현 기간 분석 (for querydsl)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 번호 미출현 기간
+     */
+    @Override
+    public List<NumberMissCountAnalysisResponse> getLottoNumberMissCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        List<NumberMissCountAnalysisResponse> result = new ArrayList<>();
+
+        for (int i = 1; i <= 45; i++) {
+            AtomicLong count = new AtomicLong();
+            from(lotto)
+                    .where(lotto.drawNo.between(startDrawNo, endDrawNo),
+                            new BooleanBuilder()
+                                    .or(lotto.lottoWinNumber.number1.eq(i))
+                                    .or(lotto.lottoWinNumber.number2.eq(i))
+                                    .or(lotto.lottoWinNumber.number3.eq(i))
+                                    .or(lotto.lottoWinNumber.number4.eq(i))
+                                    .or(lotto.lottoWinNumber.number5.eq(i))
+                                    .or(lotto.lottoWinNumber.number6.eq(i)))
+                    .select(lotto.drawNo.max())
+                    .fetch()
+                    .forEach(r -> {
+                        count.set(endDrawNo - (r == null ? startDrawNo - 1 : r));
+                    });
+
+            AtomicLong bonusCount = new AtomicLong();
+            from(lotto)
+                    .where(lotto.drawNo.between(startDrawNo, endDrawNo),
+                            new BooleanBuilder()
+                                    .or(lotto.lottoWinNumber.number1.eq(i))
+                                    .or(lotto.lottoWinNumber.number2.eq(i))
+                                    .or(lotto.lottoWinNumber.number3.eq(i))
+                                    .or(lotto.lottoWinNumber.number4.eq(i))
+                                    .or(lotto.lottoWinNumber.number5.eq(i))
+                                    .or(lotto.lottoWinNumber.number6.eq(i))
+                                    .or(lotto.lottoWinNumber.numberB.eq(i)))
+                    .select(lotto.drawNo.max())
+                    .fetch()
+                    .forEach(r -> {
+                        bonusCount.set(endDrawNo - (r == null ? startDrawNo - 1 : r));
+                    });
+
+            result.add(NumberMissCountAnalysisResponse.of(i, count.get(), bonusCount.get()));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustomImpl.java
@@ -26,11 +26,11 @@ import static com.example.projectlottery.util.StringUtils.isNullOrEmpty;
 
 public class ShopRepositoryCustomImpl extends QuerydslRepositorySupport implements ShopRepositoryCustom {
 
-    private QShop shop;
-    private QRegion region;
-    private QLottoPrize lottoPrize;
-    private QLottoWinShop lottoWinShop;
-    private QLottoWinShop lottoWinShopAnother;
+    private final QShop shop;
+    private final QRegion region;
+    private final QLottoPrize lottoPrize;
+    private final QLottoWinShop lottoWinShop;
+    private final QLottoWinShop lottoWinShopAnother;
 
     public ShopRepositoryCustomImpl() {
         super(Shop.class);

--- a/src/main/java/com/example/projectlottery/service/LottoService.java
+++ b/src/main/java/com/example/projectlottery/service/LottoService.java
@@ -4,6 +4,7 @@ import com.example.projectlottery.domain.Lotto;
 import com.example.projectlottery.dto.LottoDto;
 import com.example.projectlottery.dto.response.LottoPrizeResponse;
 import com.example.projectlottery.dto.response.LottoResponse;
+import com.example.projectlottery.dto.response.analysis.*;
 import com.example.projectlottery.dto.response.querydsl.QShopSummary;
 import com.example.projectlottery.repository.LottoRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -25,7 +26,16 @@ public class LottoService {
     private final LottoRepository lottoRepository;
 
     private final LottoPrizeService lottoPrizeService;
+
     private final RedisTemplateService redisTemplateService;
+
+    /**
+     * 로또추첨결과 정보 저장 (for 동행복권 로또추첨결과 scrap)
+     * @param dto 로또추첨결과 dto
+     */
+    public void save(LottoDto dto) {
+        lottoRepository.save(dto.toEntity());
+    }
 
     /**
      * 로또 회차별 추첨 결과 조회 (for 동행복권 scrap)
@@ -87,10 +97,60 @@ public class LottoService {
     }
 
     /**
-     * 로또추첨결과 정보 저장 (for 동행복권 로또추첨결과 scrap)
-     * @param dto 로또추첨결과 dto
+     * 로또 회차별 AC 통계 분석 (for view)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 회차별 AC 통계
      */
-    public void save(LottoDto dto) {
-        lottoRepository.save(dto.toEntity());
+    @Transactional(readOnly = true)
+    public List<NumberAcAnalysisResponse> getLottoNumberAcAnalysis(Long startDrawNo, Long endDrawNo) {
+        return lottoRepository.getLottoNumberAcAnalysis(startDrawNo, endDrawNo);
+    }
+
+    /**
+     * 로또 회차별 총합 통계 분석 (for view)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @return 로또 회차별 총합 통계
+     */
+    @Transactional(readOnly = true)
+    public List<NumberSumAnalysisResponse> getLottoNumberSumAnalysis(Long startDrawNo, Long endDrawNo) {
+        return lottoRepository.getLottoNumberSumAnalysis(startDrawNo, endDrawNo);
+    }
+
+    /**
+     * 로또 번호 출현 횟수 분석 (for view)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 번호 출현 횟수
+     */
+    @Transactional(readOnly = true)
+    public List<NumberHitCountWithBonusAnalysisResponse> getLottoNumberHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        return lottoRepository.getLottoNumberHitCountAnalysis(startDrawNo, endDrawNo, bonus);
+    }
+
+    /**
+     * 로또 번호 대역별 색상 통계 분석 (for view)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 번호 대역별 색상 통계
+     */
+    @Transactional(readOnly = true)
+    public List<NumberRangeHitCountAnalysisResponse> getLottoNumberRangeHitCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        return lottoRepository.getLottoNumberRangeHitCountAnalysis(startDrawNo, endDrawNo, bonus);
+    }
+
+    /**
+     * 로또 번호 미출현 기간 분석 (for view)
+     * @param startDrawNo 시작 회차
+     * @param endDrawNo 종료 회차
+     * @param bonus 보너스 번호 포함 여부
+     * @return 로또 번호 미출현 기간
+     */
+    @Transactional(readOnly = true)
+    public List<NumberMissCountAnalysisResponse> getLottoNumberMissCountAnalysis(Long startDrawNo, Long endDrawNo, Boolean bonus) {
+        return lottoRepository.getLottoNumberMissCountAnalysis(startDrawNo, endDrawNo, bonus);
     }
 }

--- a/src/main/resources/static/css/lotto/lottoAnalysis.css
+++ b/src/main/resources/static/css/lotto/lottoAnalysis.css
@@ -1,0 +1,368 @@
+.nav-link  {
+    color: white;
+}
+
+.tab-content {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.tab-pane {
+    width: 500px;
+    max-width: 90%;
+    display: flex;
+    justify-content: center;
+}
+
+.tab-content-inner {
+    width: 100%;
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+    background: white;
+    padding: 10px;
+}
+
+.search-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 10px;
+}
+
+.search-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 5px;
+}
+
+.search-group select {
+    width: 100px;
+}
+
+.search-sub-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 5px;
+}
+
+.fn-group {
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    justify-content: flex-end;
+}
+
+.legend {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+}
+
+.legend div {
+    display: flex;
+    flex-direction: row;
+}
+
+.legend-fill {
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+}
+
+.legend-fill div:nth-child(1) {
+    border-radius: 5px;
+    background: #fbc400;
+    width: 15px;
+}
+
+.legend-fill div:nth-child(3) {
+    border-radius: 5px;
+    background: #69c8f2;
+    width: 15px;
+}
+
+.legend-fill div:nth-child(5) {
+    border-radius: 5px;
+    background: #ff7272;
+    width: 15px;
+}
+
+.legend-fill div:nth-child(7) {
+    border-radius: 5px;
+    background: #aaaaaa;
+    width: 15px;
+}
+
+.legend-fill div:nth-child(9) {
+    border-radius: 5px;
+    background: #b0d840;
+    width: 15px;
+}
+
+.legend-fill div:nth-child(11) {
+    border-radius: 5px;
+    background: #473bc7;
+    width: 15px;
+}
+
+.ball-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.ball-info-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.ball-info-header {
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+    background: #434348;
+    padding: 10px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+
+.ball-info-header span {
+    color: white;
+}
+
+.ball-info {
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+    padding: 10px;
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+}
+
+.ball {
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    border: none;
+    border-radius: 30px;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+    font-size: 15px;
+    font-weight: bold;
+    color: white;
+    display: inline-block;
+    vertical-align: middle;
+    text-align: center;
+}
+
+.ball-count-bar {
+    width: calc(100% - 30px);
+    height: 30px;
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    align-items: center;
+}
+
+.bar-fill {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+}
+
+#analysis-content-nmc .bar-fill {
+    flex-direction: column;
+}
+
+.bar-fill-count {
+    border: none;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+}
+
+.bar-fill-count.label-mini-title {
+    color: white;
+    padding-right: 2px;
+    text-align: right;
+    font-size: 6px;
+    font-weight: lighter;
+}
+
+.bar-fill-count.n0 {
+    background-color: #fbc400;
+}
+
+.bar-fill-count.n1 {
+    background-color: #69c8f2;
+}
+
+.bar-fill-count.n2 {
+    background-color: #ff7272;
+}
+
+.bar-fill-count.n3 {
+    background-color: #aaaaaa;
+}
+
+.bar-fill-count.n4 {
+    background-color: #b0d840;
+}
+
+.bar-fill-bonus {
+    border: none;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+    background-color: #473bc7;
+}
+
+.bar-fill-bonus.label-mini-title {
+    color: white;
+    padding-right: 2px;
+    text-align: right;
+    font-size: 6px;
+    font-weight: lighter;
+}
+
+.bar-label {
+    width: 50px;
+    margin-left: auto;
+    text-align: right;
+}
+
+.btn.label-mini-title {
+    color: white;
+}
+
+.win-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.win-info-header {
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+    background: #434348;
+    padding: 10px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+
+.win-info-header span {
+    color: white;
+}
+
+.win-info-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.win-info {
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+    padding: 10px;
+    display: grid;
+    align-items: center;
+    align-content: center;
+    justify-content: center;
+    justify-items: center;
+    grid-template-columns: 1.4fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+}
+
+.win-info span:first-child {
+    width: 100%;
+    text-align: left;
+}
+
+.win-info span:last-child {
+    width: 100%;
+    text-align: right;
+    padding-right: 5px;
+}
+
+@media screen and (max-width: 768px) {
+    .legend {
+        align-items: normal;
+    }
+
+    .ball {
+        width: 29px;
+        height: 29px;
+        line-height: 29px;
+        font-size: 15px;
+    }
+
+    .ball-count-bar {
+        width: calc(100% - 29px);
+        height: 29px;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .ball {
+        width: 28px;
+        height: 28px;
+        line-height: 28px;
+        font-size: 14px;
+    }
+
+    .ball-count-bar {
+        width: calc(100% - 28px);
+        height: 28px;
+    }
+}
+
+@media screen and (max-width: 380px) {
+    .ball {
+        width: 27px;
+        height: 27px;
+        line-height: 27px;
+        font-size: 14px;
+    }
+
+    .ball-count-bar {
+        width: calc(100% - 27px);
+        height: 27px;
+    }
+}
+
+@media screen and (max-width: 350px) {
+    .ball {
+        width: 26px;
+        height: 26px;
+        line-height: 26px;
+        font-size: 13px;
+    }
+
+    .ball-count-bar {
+        width: calc(100% - 26px);
+        height: 26px;
+    }
+}
+
+@media screen and (max-width: 320px) {
+    .ball {
+        width: 25px;
+        height: 25px;
+        line-height: 25px;
+        font-size: 13px;
+    }
+
+    .ball-count-bar {
+        width: calc(100% - 25px);
+        height: 25px;
+    }
+}

--- a/src/main/resources/static/js/lotto/lottoAnalysis.js
+++ b/src/main/resources/static/js/lotto/lottoAnalysis.js
@@ -1,4 +1,843 @@
-window.addEventListener('load', function () {
-    location.href = '/';
-    alert('준비중입니다.');
+const startDrawNoAc = document.getElementById('start-draw-no-ac');
+const endDrawNoAc = document.getElementById('end-draw-no-ac');
+const analysisAcButton = document.getElementById('btn-analysis-ac');
+
+/**
+ * 회차별 AC 통계 조회 처리
+ */
+analysisAcButton.addEventListener('click', function () {
+    if (parseInt(startDrawNoAc.value) > parseInt(endDrawNoAc.value)) {
+        alert('시작 회차는 종료 회차보다 클 수 없습니다.');
+        return;
+    }
+
+    $.ajax({
+        type: 'POST',
+        url: '/L645/analysis/number-arithmetic-complexity',
+        data: {
+            startDrawNo: startDrawNoAc.value,
+            endDrawNo: endDrawNoAc.value
+        },
+        success: function (response) {
+            const analysisAc = document.querySelector('#analysis-content-ac');
+            const winInfoGrid = analysisAc.querySelector('.win-info-grid');
+
+            while (winInfoGrid.firstChild) {
+                winInfoGrid.removeChild(winInfoGrid.firstChild);
+            }
+
+            let chartData = [];
+
+            for (let i = 0; i < response.length; i++) {
+                const winInfo = document.createElement('div');
+                winInfo.classList.add('win-info');
+
+                const drawNo = document.createElement('span');
+                drawNo.classList.add('label-mini-title');
+                drawNo.textContent = response[i].drawNo;
+
+                const number1 = document.createElement('span');
+                number1.classList.add('ball');
+                number1.classList.add(getNumberClass(response[i].number1));
+                number1.textContent = response[i].number1;
+
+                const number2 = document.createElement('span');
+                number2.classList.add('ball');
+                number2.classList.add(getNumberClass(response[i].number2));
+                number2.textContent = response[i].number2;
+
+                const number3 = document.createElement('span');
+                number3.classList.add('ball');
+                number3.classList.add(getNumberClass(response[i].number3));
+                number3.textContent = response[i].number3;
+
+                const number4 = document.createElement('span');
+                number4.classList.add('ball');
+                number4.classList.add(getNumberClass(response[i].number4));
+                number4.textContent = response[i].number4;
+
+                const number5 = document.createElement('span');
+                number5.classList.add('ball');
+                number5.classList.add(getNumberClass(response[i].number5));
+                number5.textContent = response[i].number5;
+
+                const number6 = document.createElement('span');
+                number6.classList.add('ball');
+                number6.classList.add(getNumberClass(response[i].number6));
+                number6.textContent = response[i].number6;
+
+                const ac = document.createElement('span');
+                ac.classList.add('label-mini-title');
+                ac.textContent = response[i].ac;
+
+                winInfo.appendChild(drawNo);
+                winInfo.appendChild(number1);
+                winInfo.appendChild(number2);
+                winInfo.appendChild(number3);
+                winInfo.appendChild(number4);
+                winInfo.appendChild(number5);
+                winInfo.appendChild(number6);
+                winInfo.appendChild(ac);
+
+                winInfoGrid.appendChild(winInfo);
+
+                chartData.push({
+                    round: response[response.length - 1 - i].drawNo,
+                    ac: response[response.length - 1 - i].ac
+                });
+            }
+
+            updateLineChartAc(chartData);
+        },
+        error: function () {
+            alert('로그인 세션이 만료되었습니다.')
+            window.location.href = '/';
+        }
+    });
 });
+
+const analysisAllAcButton = document.getElementById('btn-analysis-all-ac');
+
+/**
+ * 회차별 AC 통계 조회 - 전체 회차 빠른 선택 버튼
+ */
+analysisAllAcButton.addEventListener('click', function () {
+    startDrawNoAc.selectedIndex = startDrawNoAc.options.length - 1;
+    endDrawNoAc.selectedIndex = 0;
+    analysisAcButton.click();
+});
+
+const analysisLatest5AcButton = document.getElementById('btn-analysis-latest5-ac');
+
+/**
+ * 회차별 AC 통계 조회 - 최근 5회차 빠른 선택 버튼
+ */
+analysisLatest5AcButton.addEventListener('click', function () {
+    startDrawNoAc.selectedIndex = 4;
+    endDrawNoAc.selectedIndex = 0;
+    analysisAcButton.click();
+});
+
+const analysisLatest10AcButton = document.getElementById('btn-analysis-latest10-ac');
+
+/**
+ * 회차별 AC 통계 조회 - 최근 10회차 빠른 선택 버튼
+ */
+analysisLatest10AcButton.addEventListener('click', function () {
+    startDrawNoAc.selectedIndex = 9;
+    endDrawNoAc.selectedIndex = 0;
+    analysisAcButton.click();
+});
+
+const analysisLatest15AcButton = document.getElementById('btn-analysis-latest15-ac');
+
+/**
+ * 회차별 AC 통계 조회 - 최근 15회차 빠른 선택 버튼
+ */
+analysisLatest15AcButton.addEventListener('click', function () {
+    startDrawNoAc.selectedIndex = 14;
+    endDrawNoAc.selectedIndex = 0;
+    analysisAcButton.click();
+});
+
+//////////////////////////////
+
+const startDrawNoSum = document.getElementById('start-draw-no-sum');
+const endDrawNoSum = document.getElementById('end-draw-no-sum');
+const analysisSumButton = document.getElementById('btn-analysis-sum');
+
+/**
+ * 회차별 총합 통계 조회 처리
+ */
+analysisSumButton.addEventListener('click', function () {
+    if (parseInt(startDrawNoSum.value) > parseInt(endDrawNoSum.value)) {
+        alert('시작 회차는 종료 회차보다 클 수 없습니다.');
+        return;
+    }
+
+    $.ajax({
+        type: 'POST',
+        url: '/L645/analysis/number-sum',
+        data: {
+            startDrawNo: startDrawNoSum.value,
+            endDrawNo: endDrawNoSum.value
+        },
+        success: function (response) {
+            const analysisSum = document.querySelector('#analysis-content-sum');
+            const winInfoGrid = analysisSum.querySelector('.win-info-grid');
+
+            while (winInfoGrid.firstChild) {
+                winInfoGrid.removeChild(winInfoGrid.firstChild);
+            }
+
+            let chartData = [];
+
+            for (let i = 0; i < response.length; i++) {
+                const winInfo = document.createElement('div');
+                winInfo.classList.add('win-info');
+
+                const drawNo = document.createElement('span');
+                drawNo.classList.add('label-mini-title');
+                drawNo.textContent = response[i].drawNo;
+
+                const number1 = document.createElement('span');
+                number1.classList.add('ball');
+                number1.classList.add(getNumberClass(response[i].number1));
+                number1.textContent = response[i].number1;
+
+                const number2 = document.createElement('span');
+                number2.classList.add('ball');
+                number2.classList.add(getNumberClass(response[i].number2));
+                number2.textContent = response[i].number2;
+
+                const number3 = document.createElement('span');
+                number3.classList.add('ball');
+                number3.classList.add(getNumberClass(response[i].number3));
+                number3.textContent = response[i].number3;
+
+                const number4 = document.createElement('span');
+                number4.classList.add('ball');
+                number4.classList.add(getNumberClass(response[i].number4));
+                number4.textContent = response[i].number4;
+
+                const number5 = document.createElement('span');
+                number5.classList.add('ball');
+                number5.classList.add(getNumberClass(response[i].number5));
+                number5.textContent = response[i].number5;
+
+                const number6 = document.createElement('span');
+                number6.classList.add('ball');
+                number6.classList.add(getNumberClass(response[i].number6));
+                number6.textContent = response[i].number6;
+
+                const sum = document.createElement('span');
+                sum.classList.add('label-mini-title');
+                sum.textContent = response[i].sum;
+
+                winInfo.appendChild(drawNo);
+                winInfo.appendChild(number1);
+                winInfo.appendChild(number2);
+                winInfo.appendChild(number3);
+                winInfo.appendChild(number4);
+                winInfo.appendChild(number5);
+                winInfo.appendChild(number6);
+                winInfo.appendChild(sum);
+
+                winInfoGrid.appendChild(winInfo);
+
+                chartData.push({
+                    round: response[response.length - 1 - i].drawNo,
+                    sum: response[response.length - 1 - i].sum
+                });
+            }
+
+            updateLineChartSum(chartData);
+        },
+        error: function () {
+            alert('로그인 세션이 만료되었습니다.')
+            window.location.href = '/';
+        }
+    });
+});
+
+const analysisAllSumButton = document.getElementById('btn-analysis-all-sum');
+
+/**
+ * 회차별 총합 통계 조회 - 전체 회차 빠른 선택 버튼
+ */
+analysisAllSumButton.addEventListener('click', function () {
+    startDrawNoSum.selectedIndex = startDrawNoSum.options.length - 1;
+    endDrawNoSum.selectedIndex = 0;
+    analysisSumButton.click();
+});
+
+const analysisLatest5SumButton = document.getElementById('btn-analysis-latest5-sum');
+
+/**
+ * 회차별 총합 통계 조회 - 최근 5회차 빠른 선택 버튼
+ */
+analysisLatest5SumButton.addEventListener('click', function () {
+    startDrawNoSum.selectedIndex = 4;
+    endDrawNoSum.selectedIndex = 0;
+    analysisSumButton.click();
+});
+
+const analysisLatest10SumButton = document.getElementById('btn-analysis-latest10-sum');
+
+/**
+ * 회차별 총합 통계 조회 - 최근 10회차 빠른 선택 버튼
+ */
+analysisLatest10SumButton.addEventListener('click', function () {
+    startDrawNoSum.selectedIndex = 9;
+    endDrawNoSum.selectedIndex = 0;
+    analysisSumButton.click();
+});
+
+const analysisLatest15SumButton = document.getElementById('btn-analysis-latest15-sum');
+
+/**
+ * 회차별 총합 통계 조회 - 최근 15회차 빠른 선택 버튼
+ */
+analysisLatest15SumButton.addEventListener('click', function () {
+    startDrawNoSum.selectedIndex = 14;
+    endDrawNoSum.selectedIndex = 0;
+    analysisSumButton.click();
+});
+
+//////////////////////////////
+
+const startDrawNoNhc = document.getElementById('start-draw-no-nhc');
+const endDrawNoNhc = document.getElementById('end-draw-no-nhc');
+const bonusYnNhc = document.getElementById('bonus-yn-nhc');
+const analysisNhcButton = document.getElementById('btn-analysis-nhc');
+
+/**
+ * 번호별 출현 횟수 통계 조회 처리
+ */
+analysisNhcButton.addEventListener('click', function () {
+    if (parseInt(startDrawNoNhc.value) > parseInt(endDrawNoNhc.value)) {
+        alert('시작 회차는 종료 회차보다 클 수 없습니다.');
+        return;
+    }
+
+    $.ajax({
+        type: 'POST',
+        url: '/L645/analysis/number-hit-count',
+        data: {
+            startDrawNo: startDrawNoNhc.value,
+            endDrawNo: endDrawNoNhc.value,
+            bonus: bonusYnNhc.checked
+        },
+        success: function (response) {
+            const maxCount = Math.max(...response.map(item => item.count));
+            const maxBonus = Math.max(...response.map(item => item.bonus));
+            const analysisNhc = document.querySelector('#analysis-content-nhc');
+            const ballInfoGrid = analysisNhc.querySelector('.ball-info-grid');
+
+            while (ballInfoGrid.firstChild) {
+                ballInfoGrid.removeChild(ballInfoGrid.firstChild);
+            }
+
+            for (let i = 0; i < response.length; i++) {
+                const ballInfo = document.createElement('div');
+                ballInfo.classList.add('ball-info');
+
+                const ball = document.createElement('span');
+                ball.classList.add('ball');
+                ball.classList.add(getNumberClass(response[i].number));
+                ball.textContent = response[i].number;
+
+                const ballCountBar = document.createElement('div');
+                ballCountBar.classList.add('ball-count-bar');
+
+                const barFill = document.createElement('div');
+                barFill.classList.add('bar-fill');
+
+                const barFillCount = document.createElement('div');
+                barFillCount.classList.add('bar-fill-count');
+                barFillCount.classList.add('label-mini-title');
+                barFillCount.classList.add(getNumberClass(response[i].number));
+                barFillCount.style.width = (response[i].count / (maxCount + maxBonus)) * 100 + '%';
+                barFillCount.style.display = response[i].count === 0 ? 'none' : 'inline-block';
+                barFillCount.style.borderRadius = bonusYnNhc.checked && response[i].bonus > 0 ? '5px 0 0 5px' : '5px';
+                barFillCount.textContent = response[i].count;
+
+                const barFillBonus = document.createElement('div');
+                barFillBonus.classList.add('bar-fill-bonus');
+                barFillBonus.classList.add('label-mini-title');
+                barFillBonus.style.width = (response[i].bonus / (maxCount + maxBonus)) * 100 + '%';
+                barFillBonus.style.display = response[i].bonus === 0 ? 'none' : 'inline-block';
+                barFillBonus.style.borderRadius = response[i].count === 0 ? '5px' : '0 5px 5px 0';
+                barFillBonus.textContent = response[i].bonus;
+
+                const barLabel = document.createElement('span');
+                barLabel.classList.add('bar-label');
+                barLabel.classList.add('label-mini-title');
+                barLabel.textContent = (response[i].count + response[i].bonus).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + '회';
+
+                barFill.appendChild(barFillCount);
+                barFill.appendChild(barFillBonus);
+
+                ballCountBar.appendChild(barFill);
+                ballCountBar.appendChild(barLabel);
+
+                ballInfo.appendChild(ball);
+                ballInfo.appendChild(ballCountBar);
+
+                ballInfoGrid.appendChild(ballInfo);
+            }
+        },
+        error: function () {
+            alert('로그인 세션이 만료되었습니다.')
+            window.location.href = '/';
+        }
+    });
+});
+
+const analysisAllNhcButton = document.getElementById('btn-analysis-all-nhc');
+
+/**
+ * 번호별 출현 횟수 통계 조회 - 전체 회차 빠른 선택 버튼
+ */
+analysisAllNhcButton.addEventListener('click', function () {
+    startDrawNoNhc.selectedIndex = startDrawNoNhc.options.length - 1;
+    endDrawNoNhc.selectedIndex = 0;
+    analysisNhcButton.click();
+});
+
+const analysisLatest5NhcButton = document.getElementById('btn-analysis-latest5-nhc');
+
+/**
+ * 번호별 출현 횟수 통계 조회 - 최근 5회차 빠른 선택 버튼
+ */
+analysisLatest5NhcButton.addEventListener('click', function () {
+    startDrawNoNhc.selectedIndex = 4;
+    endDrawNoNhc.selectedIndex = 0;
+    analysisNhcButton.click();
+});
+
+const analysisLatest10NhcButton = document.getElementById('btn-analysis-latest10-nhc');
+
+/**
+ * 번호별 출현 횟수 통계 조회 - 최근 10회차 빠른 선택 버튼
+ */
+analysisLatest10NhcButton.addEventListener('click', function () {
+    startDrawNoNhc.selectedIndex = 9;
+    endDrawNoNhc.selectedIndex = 0;
+    analysisNhcButton.click();
+});
+
+const analysisLatest15NhcButton = document.getElementById('btn-analysis-latest15-nhc');
+
+/**
+ * 번호별 출현 횟수 통계 조회 - 최근 15회차 빠른 선택 버튼
+ */
+analysisLatest15NhcButton.addEventListener('click', function () {
+    startDrawNoNhc.selectedIndex = 14;
+    endDrawNoNhc.selectedIndex = 0;
+    analysisNhcButton.click();
+});
+
+//////////////////////////////
+
+const startDrawNoNrhc = document.getElementById('start-draw-no-nrhc');
+const endDrawNoNrhc = document.getElementById('end-draw-no-nrhc');
+const bonusYnNrhc = document.getElementById('bonus-yn-nrhc');
+const analysisNrhcButton = document.getElementById('btn-analysis-nrhc');
+
+/**
+ * 번호 대역별 색상 통계 조회 처리
+ */
+analysisNrhcButton.addEventListener('click', function () {
+    if (parseInt(startDrawNoNrhc.value) > parseInt(endDrawNoNrhc.value)) {
+        alert('시작 회차는 종료 회차보다 클 수 없습니다.');
+        return;
+    }
+
+    $.ajax({
+        type: 'POST',
+        url: '/L645/analysis/number-range-hit-count',
+        data: {
+            startDrawNo: startDrawNoNrhc.value,
+            endDrawNo: endDrawNoNrhc.value,
+            bonus: bonusYnNrhc.checked
+        },
+        success: function (response) {
+            const maxCount = Math.max(...response.map(item => item.count));
+            const maxBonus = Math.max(...response.map(item => item.bonus));
+            const analysisNrhc = document.querySelector('#analysis-content-nrhc');
+            const ballInfoGrid = analysisNrhc.querySelector('.ball-info-grid');
+
+            while (ballInfoGrid.firstChild) {
+                ballInfoGrid.removeChild(ballInfoGrid.firstChild);
+            }
+
+            for (let i = 0; i < response.length; i++) {
+                const ballInfo = document.createElement('div');
+                ballInfo.classList.add('ball-info');
+
+                const ball = document.createElement('span');
+                ball.classList.add('ball');
+                ball.classList.add(getNumberClass(response[i].numberRange));
+                // ball.textContent = response[i].numberRange;
+
+                const ballCountBar = document.createElement('div');
+                ballCountBar.classList.add('ball-count-bar');
+
+                const barFill = document.createElement('div');
+                barFill.classList.add('bar-fill');
+
+                const barFillCount = document.createElement('div');
+                barFillCount.classList.add('bar-fill-count');
+                barFillCount.classList.add('label-mini-title');
+                barFillCount.classList.add(getNumberClass(response[i].numberRange));
+                barFillCount.style.width = (response[i].count / (maxCount + maxBonus)) * 100 + '%';
+                barFillCount.style.display = response[i].count === 0 ? 'none' : 'inline-block';
+                barFillCount.style.borderRadius = bonusYnNrhc.checked && response[i].bonus > 0 ? '5px 0 0 5px' : '5px';
+                barFillCount.textContent = response[i].count;
+
+                const barFillBonus = document.createElement('div');
+                barFillBonus.classList.add('bar-fill-bonus');
+                barFillBonus.classList.add('label-mini-title');
+                barFillBonus.style.width = (response[i].bonus / (maxCount + maxBonus)) * 100 + '%';
+                barFillBonus.style.display = response[i].bonus === 0 ? 'none' : 'inline-block';
+                barFillBonus.style.borderRadius = response[i].count === 0 ? '5px' : '0 5px 5px 0';
+                barFillBonus.textContent = response[i].bonus;
+
+                const barLabel = document.createElement('span');
+                barLabel.classList.add('bar-label');
+                barLabel.classList.add('label-mini-title');
+                barLabel.textContent = (response[i].count + response[i].bonus).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + '회';
+
+                barFill.appendChild(barFillCount);
+                barFill.appendChild(barFillBonus);
+
+                ballCountBar.appendChild(barFill);
+                ballCountBar.appendChild(barLabel);
+
+                ballInfo.appendChild(ball);
+                ballInfo.appendChild(ballCountBar);
+
+                ballInfoGrid.appendChild(ballInfo);
+            }
+        },
+        error: function () {
+            alert('로그인 세션이 만료되었습니다.')
+            window.location.href = '/';
+        }
+    });
+});
+
+const analysisAllNrhcButton = document.getElementById('btn-analysis-all-nrhc');
+
+/**
+ * 번호 대역별 색상 통계 조회 - 전체 회차 빠른 선택 버튼
+ */
+analysisAllNrhcButton.addEventListener('click', function () {
+    startDrawNoNrhc.selectedIndex = startDrawNoNrhc.options.length - 1;
+    endDrawNoNrhc.selectedIndex = 0;
+    analysisNrhcButton.click();
+});
+
+const analysisLatest5NrhcButton = document.getElementById('btn-analysis-latest5-nrhc');
+
+/**
+ * 번호 대역별 색상 통계 조회 - 최근 5회차 빠른 선택 버튼
+ */
+analysisLatest5NrhcButton.addEventListener('click', function () {
+    startDrawNoNrhc.selectedIndex = 4;
+    endDrawNoNrhc.selectedIndex = 0;
+    analysisNrhcButton.click();
+});
+
+const analysisLatest10NrhcButton = document.getElementById('btn-analysis-latest10-nrhc');
+
+/**
+ * 번호 대역별 색상 통계 조회 - 최근 10회차 빠른 선택 버튼
+ */
+analysisLatest10NrhcButton.addEventListener('click', function () {
+    startDrawNoNrhc.selectedIndex = 9;
+    endDrawNoNrhc.selectedIndex = 0;
+    analysisNrhcButton.click();
+});
+
+const analysisLatest15NrhcButton = document.getElementById('btn-analysis-latest15-nrhc');
+
+/**
+ * 번호 대역별 색상 통계 조회 - 최근 15회차 빠른 선택 버튼
+ */
+analysisLatest15NrhcButton.addEventListener('click', function () {
+    startDrawNoNrhc.selectedIndex = 14;
+    endDrawNoNrhc.selectedIndex = 0;
+    analysisNrhcButton.click();
+});
+
+//////////////////////////////
+
+const startDrawNoNmc = document.getElementById('start-draw-no-nmc');
+const endDrawNoNmc = document.getElementById('end-draw-no-nmc');
+const bonusYnNmc = document.getElementById('bonus-yn-nmc');
+const analysisNmcButton = document.getElementById('btn-analysis-nmc');
+
+/**
+ * 번호별 미출현 기간 통계 조회 처리
+ */
+analysisNmcButton.addEventListener('click', function () {
+    if (parseInt(startDrawNoNmc.value) > parseInt(endDrawNoNmc.value)) {
+        alert('시작 회차는 종료 회차보다 클 수 없습니다.');
+        return;
+    }
+
+    $.ajax({
+        type: 'POST',
+        url: '/L645/analysis/number-miss-count',
+        data: {
+            startDrawNo: startDrawNoNmc.value,
+            endDrawNo: endDrawNoNmc.value,
+            bonus: bonusYnNmc.checked
+        },
+        success: function (response) {
+            const maxCount = Math.max(...response.map(item => item.count));
+            const maxBonus = Math.max(...response.map(item => item.bonus));
+            const analysisNmc = document.querySelector('#analysis-content-nmc');
+            const ballInfoGrid = analysisNmc.querySelector('.ball-info-grid');
+
+            while (ballInfoGrid.firstChild) {
+                ballInfoGrid.removeChild(ballInfoGrid.firstChild);
+            }
+
+            for (let i = 0; i < response.length; i++) {
+                const ballInfo = document.createElement('div');
+                ballInfo.classList.add('ball-info');
+
+                const ball = document.createElement('span');
+                ball.classList.add('ball');
+                ball.classList.add(getNumberClass(response[i].number));
+                ball.textContent = response[i].number;
+
+                const ballCountBar = document.createElement('div');
+                ballCountBar.classList.add('ball-count-bar');
+
+                const barFill = document.createElement('div');
+                barFill.classList.add('bar-fill');
+
+                const barFillCount = document.createElement('div');
+                barFillCount.classList.add('bar-fill-count');
+                barFillCount.classList.add('label-mini-title');
+                barFillCount.classList.add(getNumberClass(response[i].number));
+                barFillCount.style.width = (response[i].count / (maxCount > maxBonus ? maxCount : maxBonus)) * 100 + '%';
+                barFillCount.style.borderRadius = '5px';
+                barFillCount.textContent = response[i].count === 0 ? '　' : response[i].count;
+
+                const barFillBonus = document.createElement('div');
+                barFillBonus.classList.add('bar-fill-bonus');
+                barFillBonus.classList.add('label-mini-title');
+                barFillBonus.classList.add(getNumberClass(response[i].number));
+                barFillBonus.style.width = (response[i].bonus / (maxCount > maxBonus ? maxCount : maxBonus)) * 100 + '%';
+                barFillBonus.style.borderRadius = '5px';
+                barFillBonus.textContent = response[i].bonus === 0 ? '　' : response[i].bonus;
+
+                const barLabel = document.createElement('span');
+                barLabel.classList.add('bar-label');
+                barLabel.classList.add('label-mini-title');
+                barLabel.textContent = (bonusYnNmc.checked ? response[i].bonus : response[i].count).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + '주';
+
+                barFill.appendChild(barFillCount);
+                if (bonusYnNmc.checked) barFill.appendChild(barFillBonus);
+
+                ballCountBar.appendChild(barFill);
+                ballCountBar.appendChild(barLabel);
+
+                ballInfo.appendChild(ball);
+                ballInfo.appendChild(ballCountBar);
+
+                ballInfoGrid.appendChild(ballInfo);
+            }
+        },
+        error: function () {
+            alert('로그인 세션이 만료되었습니다.')
+            window.location.href = '/';
+        }
+    });
+});
+
+const analysisAllNmcButton = document.getElementById('btn-analysis-all-nmc');
+
+/**
+ * 번호별 미출현 기간 통계 조회 - 전체 회차 빠른 선택 버튼
+ */
+analysisAllNmcButton.addEventListener('click', function () {
+    startDrawNoNmc.selectedIndex = startDrawNoNmc.options.length - 1;
+    endDrawNoNmc.selectedIndex = 0;
+    analysisNmcButton.click();
+});
+
+const analysisLatest5NmcButton = document.getElementById('btn-analysis-latest5-nmc');
+
+/**
+ * 번호별 미출현 기간 통계 조회 - 최근 5회차 빠른 선택 버튼
+ */
+analysisLatest5NmcButton.addEventListener('click', function () {
+    startDrawNoNmc.selectedIndex = 4;
+    endDrawNoNmc.selectedIndex = 0;
+    analysisNmcButton.click();
+});
+
+const analysisLatest10NmcButton = document.getElementById('btn-analysis-latest10-nmc');
+
+/**
+ * 번호별 미출현 기간 통계 조회 - 최근 10회차 빠른 선택 버튼
+ */
+analysisLatest10NmcButton.addEventListener('click', function () {
+    startDrawNoNmc.selectedIndex = 9;
+    endDrawNoNmc.selectedIndex = 0;
+    analysisNmcButton.click();
+});
+
+const analysisLatest15NmcButton = document.getElementById('btn-analysis-latest15-nmc');
+
+/**
+ * 번호별 미출현 기간 통계 조회 - 최근 15회차 빠른 선택 버튼
+ */
+analysisLatest15NmcButton.addEventListener('click', function () {
+    startDrawNoNmc.selectedIndex = 14;
+    endDrawNoNmc.selectedIndex = 0;
+    analysisNmcButton.click();
+});
+
+//////////////////////////////
+
+/**
+ * ball class 계산 및 부여
+ * @param number 선택 번호
+ * @returns {string} ball class
+ */
+function getNumberClass(number) {
+    if (number >= 1 && number <= 10) {
+        return 'n0';
+    } else if (number >= 11 && number <= 20) {
+        return 'n1';
+    } else if (number >= 21 && number <= 30) {
+        return 'n2';
+    } else if (number >= 31 && number <= 40) {
+        return 'n3';
+    } else if (number >= 41 && number <= 45) {
+        return 'n4';
+    } else {
+        return '';
+    }
+}
+
+//////////////////////////////
+
+const ctxLineChartAc = document.getElementById('line-chart-ac').getContext('2d');
+const lineChartAc = new Chart(ctxLineChartAc, {
+    type: 'line',
+    data: [],
+    options: {
+        responsive: true,
+        plugins: {
+            zoom: {
+                pan: {
+                    enabled: true,
+                    mode: 'x',
+                    speed: 10
+                },
+                zoom: {
+                    wheel: {
+                        enabled: true
+                    },
+                    pinch: {
+                        enabled: true
+                    },
+                    mode: 'x'
+                }
+            }
+        },
+        scales: {
+            y: {
+                beginAtZero: true,
+                suggestedMax: 10,
+                ticks: {
+                    stepSize: 2,
+                    autoSkip: false
+                }
+            }
+        }
+    }
+});
+
+/**
+ * 회차별 AC 값을 차트 데이터로 변환
+ */
+function convertDataToLineChartAc(data) {
+    return {
+        labels: data.map(function (item) {
+            return item.round;
+        }),
+        datasets: [{
+            label: 'AC',
+            data: data.map(function (item) {
+                return item.ac;
+            }),
+            borderColor: 'rgba(255, 99, 132, 1)',
+            backgroundColor: 'rgba(255, 99, 132, 0.2)',
+            borderWidth: 1,
+            pointRadius: 1
+        }]
+    };
+}
+
+/**
+ * 회차별 AC 차트 업데이트
+ */
+function updateLineChartAc(data) {
+    lineChartAc.data = convertDataToLineChartAc(data);
+    lineChartAc.resetZoom();
+    lineChartAc.update(); // 차트를 다시 그려서 업데이트된 데이터와 y 축 범위를 반영
+}
+
+//////////////////////////////
+
+const ctxLineChartSum = document.getElementById('line-chart-sum').getContext('2d');
+const lineChartSum = new Chart(ctxLineChartSum, {
+    type: 'line',
+    data: [],
+    options: {
+        responsive: true,
+        plugins: {
+            zoom: {
+                pan: {
+                    enabled: true,
+                    mode: 'x',
+                    speed: 10
+                },
+                zoom: {
+                    wheel: {
+                        enabled: true
+                    },
+                    pinch: {
+                        enabled: true
+                    },
+                    mode: 'x'
+                }
+            }
+        },
+        scales: {
+            y: {
+                beginAtZero: true,
+                suggestedMax: 255
+            }
+        }
+    }
+});
+
+/**
+ * 회차별 총합 값을 차트 데이터로 변환
+ */
+function convertDataToLineChartSum(data) {
+    return {
+        labels: data.map(function (item) {
+            return item.round;
+        }),
+        datasets: [{
+            label: 'SUM',
+            data: data.map(function (item) {
+                return item.sum;
+            }),
+            borderColor: 'rgba(255, 99, 132, 1)',
+            backgroundColor: 'rgba(255, 99, 132, 0.2)',
+            borderWidth: 1,
+            pointRadius: 1
+        }]
+    };
+}
+
+/**
+ * 회차별 총합 차트 업데이트
+ */
+function updateLineChartSum(data) {
+    lineChartSum.data = convertDataToLineChartSum(data);
+    lineChartSum.resetZoom();
+    lineChartSum.update(); // 차트를 다시 그려서 업데이트된 데이터와 y 축 범위를 반영
+}

--- a/src/main/resources/templates/lotto/lottoAnalysis.html
+++ b/src/main/resources/templates/lotto/lottoAnalysis.html
@@ -7,10 +7,10 @@
     <meta name="author" charset="PARK GI-PYO">
     <title>project-lottery</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/common.css?v=20230525" rel="stylesheet">
-    <link href="/css/header.css?v=20230525" rel="stylesheet">
-    <link href="/css/footer.css?v=20230525" rel="stylesheet">
-    <link href="/css/lotto/lottoAnalysis.css?v=20230525" rel="stylesheet">
+    <link href="/css/common.css?v=20230531" rel="stylesheet">
+    <link href="/css/header.css?v=20230531" rel="stylesheet">
+    <link href="/css/footer.css?v=20230531" rel="stylesheet">
+    <link href="/css/lotto/lottoAnalysis.css?v=20230531" rel="stylesheet">
 </head>
 <body>
 <header id="header">
@@ -19,14 +19,303 @@
 </header>
 <main class="container">
     <div class="content-group">
+        <ul class="nav nav-pills" id="tool-tab" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text active" id="analysis-tab-ac" data-bs-toggle="pill" data-bs-target="#analysis-content-ac" type="button" role="tab" aria-controls="analysis-content-ac" aria-selected="true">
+                    AC
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text" id="analysis-tab-sum" data-bs-toggle="pill" data-bs-target="#analysis-content-sum" type="button" role="tab" aria-controls="analysis-content-sum" aria-selected="false">
+                    총합
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text" id="analysis-tab-nhc" data-bs-toggle="pill" data-bs-target="#analysis-content-nhc" type="button" role="tab" aria-controls="analysis-content-nhc" aria-selected="false">
+                    출현
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text" id="analysis-tab-nrhc" data-bs-toggle="pill" data-bs-target="#analysis-content-nrhc" type="button" role="tab" aria-controls="analysis-content-nrhc" aria-selected="false">
+                    색상
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text" id="analysis-tab-nmc" data-bs-toggle="pill" data-bs-target="#analysis-content-nmc" type="button" role="tab" aria-controls="analysis-content-nmc" aria-selected="false">
+                    미출현
+                </button>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div class="tab-pane fade show active" id="analysis-content-ac" role="tabpanel" aria-labelledby="analysis-tab-ac">
+                <div class="tab-content-inner">
+                    <span class="label-title">AC</span>
+                    <br>
+                    <span class="label-mini-title">회차별 AC(Arithmetic Complexity) 값을 분석합니다.</span>
+                    <hr>
+                    <div class="analysis-wrapper">
+                        <div class="search-grid">
+                            <div class="search-group">
+                                <select class="form-select label-mini-title" name="startDrawNo" id="start-draw-no-ac">
+                                    <option>0회</option>
+                                </select>
+                                <span class="label-mini-title">~</span>
+                                <select class="form-select label-mini-title" name="endDrawNo" id="end-draw-no-ac">
+                                    <option>0회</option>
+                                </select>
+                                <button class="btn btn-primary label-mini-title" id="btn-analysis-ac">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </div>
+                            <div class="fn-group">
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-all-ac">전체</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest5-ac">최근 5주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest10-ac">최근 10주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest15-ac">최근 15주</button>
+                            </div>
+                        </div>
+                        <hr>
+                        <canvas id="line-chart-ac"></canvas>
+                        <hr>
+                        <div class="win-grid">
+                            <div class="win-info-header">
+                                <span class="label-mini-title">회차</span>
+                                <span class="label-mini-title">당첨번호</span>
+                                <span class="label-mini-title">AC</span>
+                            </div>
+                            <div class="win-info-grid"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="tab-pane fade" id="analysis-content-sum" role="tabpanel" aria-labelledby="analysis-tab-sum">
+                <div class="tab-content-inner">
+                    <span class="label-title">총합</span>
+                    <br>
+                    <span class="label-mini-title">회차별 당첨번호 합계 값을 분석합니다.</span>
+                    <hr>
+                    <div class="analysis-wrapper">
+                        <div class="search-grid">
+                            <div class="search-group">
+                                <select class="form-select label-mini-title" name="startDrawNo" id="start-draw-no-sum">
+                                    <option>0회</option>
+                                </select>
+                                <span class="label-mini-title">~</span>
+                                <select class="form-select label-mini-title" name="endDrawNo" id="end-draw-no-sum">
+                                    <option>0회</option>
+                                </select>
+                                <button class="btn btn-primary label-mini-title" id="btn-analysis-sum">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </div>
+                            <div class="fn-group">
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-all-sum">전체</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest5-sum">최근 5주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest10-sum">최근 10주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest15-sum">최근 15주</button>
+                            </div>
+                        </div>
+                        <hr>
+                        <canvas id="line-chart-sum"></canvas>
+                        <hr>
+                        <div class="win-grid">
+                            <div class="win-info-header">
+                                <span class="label-mini-title">회차</span>
+                                <span class="label-mini-title">당첨번호</span>
+                                <span class="label-mini-title">합계</span>
+                            </div>
+                            <div class="win-info-grid"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="tab-pane fade" id="analysis-content-nhc" role="tabpanel" aria-labelledby="analysis-tab-nhc">
+                <div class="tab-content-inner">
+                    <span class="label-title">출현</span>
+                    <br>
+                    <span class="label-mini-title">번호별 출현 횟수를 분석합니다.</span>
+                    <hr>
+                    <div class="analysis-wrapper">
+                        <div class="search-grid">
+                            <div class="search-sub-group">
+                                <input type="checkbox" name="bonus-yn" id="bonus-yn-nhc">
+                                <label class="label-mini-title" for="bonus-yn-nhc">보너스번호 포함</label>
+                            </div>
+                            <div class="search-group">
+                                <select class="form-select label-mini-title" name="startDrawNo" id="start-draw-no-nhc">
+                                    <option>0회</option>
+                                </select>
+                                <span class="label-mini-title">~</span>
+                                <select class="form-select label-mini-title" name="endDrawNo" id="end-draw-no-nhc">
+                                    <option>0회</option>
+                                </select>
+                                <button class="btn btn-primary label-mini-title" id="btn-analysis-nhc">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </div>
+                            <div class="fn-group">
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-all-nhc">전체</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest5-nhc">최근 5주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest10-nhc">최근 10주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest15-nhc">최근 15주</button>
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="legend">
+                            <div class="legend-fill">
+                                <div></div>
+                                <span class="label-mini-title">1~10</span>
+                                <div></div>
+                                <span class="label-mini-title">11~20</span>
+                                <div></div>
+                                <span class="label-mini-title">21~30</span>
+                                <div></div>
+                                <span class="label-mini-title">31~40</span>
+                                <div></div>
+                                <span class="label-mini-title">41~45</span>
+                                <div></div>
+                                <span class="label-mini-title">보너스번호</span>
+                            </div>
+                        </div>
+                        <div class="ball-grid">
+                            <div class="ball-info-header">
+                                <span class="label-mini-title">번호</span>
+                                <span class="label-mini-title">출현</span>
+                            </div>
+                            <div class="ball-info-grid"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="tab-pane fade" id="analysis-content-nrhc" role="tabpanel" aria-labelledby="analysis-tab-nrhc">
+                <div class="tab-content-inner">
+                    <span class="label-title">색상</span>
+                    <br>
+                    <span class="label-mini-title">번호 색상별 출현 횟수를 분석합니다.</span>
+                    <hr>
+                    <div class="analysis-wrapper">
+                        <div class="search-grid">
+                            <div class="search-sub-group">
+                                <input type="checkbox" name="bonus-yn" id="bonus-yn-nrhc">
+                                <label class="label-mini-title" for="bonus-yn-nrhc">보너스번호 포함</label>
+                            </div>
+                            <div class="search-group">
+                                <select class="form-select label-mini-title" name="startDrawNo" id="start-draw-no-nrhc">
+                                    <option>0회</option>
+                                </select>
+                                <span class="label-mini-title">~</span>
+                                <select class="form-select label-mini-title" name="endDrawNo" id="end-draw-no-nrhc">
+                                    <option>0회</option>
+                                </select>
+                                <button class="btn btn-primary label-mini-title" id="btn-analysis-nrhc">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </div>
+                            <div class="fn-group">
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-all-nrhc">전체</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest5-nrhc">최근 5주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest10-nrhc">최근 10주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest15-nrhc">최근 15주</button>
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="legend">
+                            <div class="legend-fill">
+                                <div></div>
+                                <span class="label-mini-title">1~10</span>
+                                <div></div>
+                                <span class="label-mini-title">11~20</span>
+                                <div></div>
+                                <span class="label-mini-title">21~30</span>
+                                <div></div>
+                                <span class="label-mini-title">31~40</span>
+                                <div></div>
+                                <span class="label-mini-title">41~45</span>
+                                <div></div>
+                                <span class="label-mini-title">보너스번호</span>
+                            </div>
+                        </div>
+                        <div class="ball-grid">
+                            <div class="ball-info-header">
+                                <span class="label-mini-title">색상</span>
+                                <span class="label-mini-title">출현</span>
+                            </div>
+                            <div class="ball-info-grid"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="tab-pane fade" id="analysis-content-nmc" role="tabpanel" aria-labelledby="analysis-tab-nmc">
+                <div class="tab-content-inner">
+                    <span class="label-title">미출현</span>
+                    <br>
+                    <span class="label-mini-title">번호별 미출현 기간을 분석합니다.</span>
+                    <hr>
+                    <div class="analysis-wrapper">
+                        <div class="search-grid">
+                            <div class="search-sub-group">
+                                <input type="checkbox" name="bonus-yn" id="bonus-yn-nmc">
+                                <label class="label-mini-title" for="bonus-yn-nmc">보너스번호 포함</label>
+                            </div>
+                            <div class="search-group">
+                                <select class="form-select label-mini-title" name="startDrawNo" id="start-draw-no-nmc">
+                                    <option>0회</option>
+                                </select>
+                                <span class="label-mini-title">~</span>
+                                <select class="form-select label-mini-title" name="endDrawNo" id="end-draw-no-nmc">
+                                    <option>0회</option>
+                                </select>
+                                <button class="btn btn-primary label-mini-title" id="btn-analysis-nmc">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </div>
+                            <div class="fn-group">
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-all-nmc">전체</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest5-nmc">최근 5주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest10-nmc">최근 10주</button>
+                                <button class="btn btn-secondary label-mini-title" id="btn-analysis-latest15-nmc">최근 15주</button>
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="legend">
+                            <div class="legend-fill">
+                                <div></div>
+                                <span class="label-mini-title">1~10</span>
+                                <div></div>
+                                <span class="label-mini-title">11~20</span>
+                                <div></div>
+                                <span class="label-mini-title">21~30</span>
+                                <div></div>
+                                <span class="label-mini-title">31~40</span>
+                                <div></div>
+                                <span class="label-mini-title">41~45</span>
+                                <div></div>
+                                <span class="label-mini-title">보너스번호</span>
+                            </div>
+                        </div>
+                        <div class="ball-grid">
+                            <div class="ball-info-header">
+                                <span class="label-mini-title">번호</span>
+                                <span class="label-mini-title">미출현</span>
+                            </div>
+                            <div class="ball-info-grid"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </main>
 <script src="https://kit.fontawesome.com/9f7c487e95.js" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-<script type="text/javascript" src="/js/lotto/lottoAnalysis.js?v=20230525"></script>
-<script type="text/javascript" src="/js/footer.js?v=20230525"></script>
-<script type="text/javascript" src="/js/header.js?v=20230525"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.3.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
+<script type="text/javascript" src="/js/lotto/lottoAnalysis.js?v=20230531"></script>
+<script type="text/javascript" src="/js/footer.js?v=20230531"></script>
+<script type="text/javascript" src="/js/header.js?v=20230531"></script>
 <footer id="footer">
     <hr>
     footer 삽입부

--- a/src/main/resources/templates/lotto/lottoAnalysis.th.xml
+++ b/src/main/resources/templates/lotto/lottoAnalysis.th.xml
@@ -2,4 +2,99 @@
 <thlogic>
     <attr sel="#header" th:replace="~{header :: header}"/>
     <attr sel="#footer" th:replace="~{footer :: footer}"/>
+
+    <attr sel="#analysis-content-ac">
+        <attr sel=".search-grid">
+            <attr sel="#start-draw-no-ac">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, '1')}"/>
+            </attr>
+            <attr sel="#end-draw-no-ac">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, latestDrawNo)}"/>
+            </attr>
+        </attr>
+    </attr>
+
+    <attr sel="#analysis-content-sum">
+        <attr sel=".search-grid">
+            <attr sel="#start-draw-no-sum">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, '1')}"/>
+            </attr>
+            <attr sel="#end-draw-no-sum">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, latestDrawNo)}"/>
+            </attr>
+        </attr>
+    </attr>
+
+    <attr sel="#analysis-content-nhc">
+        <attr sel=".search-grid">
+            <attr sel="#start-draw-no-nhc">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, '1')}"/>
+            </attr>
+            <attr sel="#end-draw-no-nhc">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, latestDrawNo)}"/>
+            </attr>
+        </attr>
+    </attr>
+    
+    <attr sel="#analysis-content-nrhc">
+        <attr sel=".search-grid">
+            <attr sel="#start-draw-no-nrhc">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, '1')}"/>
+            </attr>
+            <attr sel="#end-draw-no-nrhc">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, latestDrawNo)}"/>
+            </attr>
+        </attr>
+    </attr>
+
+    <attr sel="#analysis-content-nmc">
+        <attr sel=".search-grid">
+            <attr sel="#start-draw-no-nmc">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, '1')}"/>
+            </attr>
+            <attr sel="#end-draw-no-nmc">
+                <attr sel="option"
+                      th:each="drawNo : ${#numbers.sequence(latestDrawNo, 1)}"
+                      th:value="${drawNo}"
+                      th:text="${drawNo} + '회'"
+                      th:selected="${#strings.equals(drawNo.toString, latestDrawNo)}"/>
+            </attr>
+        </attr>
+    </attr>
 </thlogic>


### PR DESCRIPTION
로또 분석, 통계 페이지 개발 관련 PR 이다.

현재 5개의 통계를 추가했고, 회차별 혹은 당첨번호별 통계 수치이다.
chart js 를 적용 등 수치를 쉽게 확인하고 비교할 수 있도록 했다.

This closes #115 