### PR TITLE
신흥명당

### DIFF
--- a/src/main/java/com/example/projectlottery/controller/ShopController.java
+++ b/src/main/java/com/example/projectlottery/controller/ShopController.java
@@ -83,13 +83,23 @@ public class ShopController {
      */
     @GetMapping("/ranking")
     public String ranking(ModelMap map) {
+        //로또 명당 목록
         List<QShopSummary> ranking = shopService.getShopRankingResponse();
 
         //리스트를 4개의 조각으로 나눠서 map binding
-        map.addAttribute("chucked1", ranking.subList(0, 10));
-        map.addAttribute("chucked2", ranking.subList(10, 30));
-        map.addAttribute("chucked3", ranking.subList(30, 50));
-        map.addAttribute("chucked4", ranking.subList(50, 100));
+        map.addAttribute("total1", ranking.subList(0, 10));
+        map.addAttribute("total2", ranking.subList(10, 30));
+        map.addAttribute("total3", ranking.subList(30, 50));
+        map.addAttribute("total4", ranking.subList(50, 100));
+
+        //신흥 명당 목록
+        List<QShopSummary> recentRanking = shopService.getShopRecentRankingResponse();
+
+        //리스트를 4개의 조각으로 나눠서 map binding
+        map.addAttribute("recent1", recentRanking.subList(0, 10));
+        map.addAttribute("recent2", recentRanking.subList(10, 30));
+        map.addAttribute("recent3", recentRanking.subList(30, 50));
+        map.addAttribute("recent4", recentRanking.subList(50, 100));
 
         return "shop/shopRanking";
     }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustom.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/ShopRepositoryCustom.java
@@ -38,6 +38,12 @@ public interface ShopRepositoryCustom {
     List<QShopSummary> getShopSummaryResponseForRanking();
 
     /**
+     * 로또 명당 페이지 - 신흥 명당 목록 조회 (최근 52주)
+     * @return 로또 명당 목록
+     */
+    List<QShopSummary> getShopSummaryResponseForRecentRanking();
+
+    /**
      * 로또판매점 상세 페이지 - 상단 1, 2등 당첨 집계 요약 조회
      * @param shopId 판매점 id
      * @return 1, 2등 당첨 집계 요약

--- a/src/main/java/com/example/projectlottery/service/ShopService.java
+++ b/src/main/java/com/example/projectlottery/service/ShopService.java
@@ -120,12 +120,29 @@ public class ShopService {
      */
     @Transactional(readOnly = true)
     public List<QShopSummary> getShopRankingResponse() {
-        List<QShopSummary> shopRankingResponses = redisTemplateService.getAllShopRanking(); //redis cache
+        List<QShopSummary> shopRankingResponses = redisTemplateService.getAllShopRanking(false); //redis cache
 
         if (shopRankingResponses.isEmpty()) { //redis 조회 실패 시, redis 갱신
             shopRankingResponses = shopRepository.getShopSummaryResponseForRanking();
 
-            redisTemplateService.saveShopRanking(shopRankingResponses); //redis cache
+            redisTemplateService.saveShopRanking(false, shopRankingResponses); //redis cache
+        }
+
+        return shopRankingResponses;
+    }
+
+    /**
+     * 신흥명당 목록 조회 - 최근 52주 (for view)
+     * @return 신흥명당 - 최근 52주
+     */
+    @Transactional(readOnly = true)
+    public List<QShopSummary> getShopRecentRankingResponse() {
+        List<QShopSummary> shopRankingResponses = redisTemplateService.getAllShopRanking(true); //redis cache
+
+        if (shopRankingResponses.isEmpty()) { //redis 조회 실패 시, redis 갱신
+            shopRankingResponses = shopRepository.getShopSummaryResponseForRecentRanking();
+
+            redisTemplateService.saveShopRanking(true, shopRankingResponses); //redis cache
         }
 
         return shopRankingResponses;

--- a/src/main/resources/static/css/shop/shopRanking.css
+++ b/src/main/resources/static/css/shop/shopRanking.css
@@ -1,3 +1,21 @@
+.nav-link  {
+    color: white;
+}
+
+.tab-header {
+    text-align: right;
+}
+
+.label-white {
+    color: white;
+}
+
+.tab-content {
+    display: grid;
+    gap: 10px;
+    width: 100%;
+}
+
 .accordion {
     width: 100%;
 }

--- a/src/main/resources/templates/shop/shopRanking.html
+++ b/src/main/resources/templates/shop/shopRanking.html
@@ -7,10 +7,10 @@
     <meta name="author" charset="PARK GI-PYO">
     <title>project-lottery</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/common.css?v=2023061022" rel="stylesheet">
-    <link href="/css/header.css?v=2023061022" rel="stylesheet">
-    <link href="/css/footer.css?v=2023061022" rel="stylesheet">
-    <link href="/css/shop/shopRanking.css?v=2023061022" rel="stylesheet">
+    <link href="/css/common.css?v=2024030113" rel="stylesheet">
+    <link href="/css/header.css?v=2024030113" rel="stylesheet">
+    <link href="/css/footer.css?v=2024030113" rel="stylesheet">
+    <link href="/css/shop/shopRanking.css?v=2024030113" rel="stylesheet">
 </head>
 <body>
 <header id="header">
@@ -19,173 +19,361 @@
 </header>
 <main class="container">
     <div class="content-group">
-        <!-- BEGIN TOP 10 -->
-        <div class="accordion">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="ranking-1st-section-header">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-1st-section-body" aria-expanded="true" aria-controls="ranking-1st-section-body">
-                        <img class="ico" src="/img/ico-1st-prize.png">
-                        <span class="label-title">TOP 10</span>
-                    </button>
-                </h2>
-                <div id="ranking-1st-section-body" class="accordion-collapse collapse show" aria-labelledby="ranking-1st-section-header">
-                    <div class="accordion-body">
-                        <div class="card" id="lotto-shop-ranking1">
-                            <div class="card-header">
-                                <div class="shop-info">
-                                    <div class="shop-info-inner">
-                                        <span class="label-mini-title">[0]</span>
-                                        <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
-                                    </div>
-                                    <div>
-                                        <span class="label-text">-</span>
+        <ul class="nav nav-pills" id="ranking-tab" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text active" id="total-ranking-tab" data-bs-toggle="pill" data-bs-target="#total-ranking-content" type="button" role="tab" aria-controls="total-ranking-content" aria-selected="true">
+                    로또명당
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text" id="recent-ranking-tab" data-bs-toggle="pill" data-bs-target="#recent-ranking-content" type="button" role="tab" aria-controls="recent-ranking-content" aria-selected="false">
+                    신흥명당
+                </button>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div class="tab-pane fade show active" id="total-ranking-content" role="tabpanel" aria-labelledby="total-ranking-tab">
+                <div class="tab-header">
+                    <span class="label-mini-title label-white">&#9989 262회부터 모든 회차의 판매점 배출 등위를 합산한 결과</span>
+                </div>
+                <div class="tab-content-inner">
+                    <!-- BEGIN TOP 10 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="ranking-1st-section-header">
+                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-1st-section-body" aria-expanded="true" aria-controls="ranking-1st-section-body">
+                                    <img class="ico" src="/img/ico-1st-prize.png">
+                                    <span class="label-title">TOP 10</span>
+                                </button>
+                            </h2>
+                            <div id="ranking-1st-section-body" class="accordion-collapse collapse show" aria-labelledby="ranking-1st-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-ranking1">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="shop-win-count">
-                                    <div class="shop-win-count-inner">
-                                        <img src="/img/ico-1st-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                        <img src="/img/ico-2nd-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="card-body">
-                                <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </div>
-        <!-- END TOP 10 -->
-        <!-- BEGIN TOP 30 -->
-        <div class="accordion">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="ranking-2nd-section-header">
-                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-2nd-section-body" aria-expanded="false" aria-controls="ranking-2nd-section-body">
-                        <img class="ico" src="/img/ico-2nd-prize.png">
-                        <span class="label-title">TOP 30</span>
-                    </button>
-                </h2>
-                <div id="ranking-2nd-section-body" class="accordion-collapse collapse" aria-labelledby="ranking-2nd-section-header">
-                    <div class="accordion-body">
-                        <div class="card" id="lotto-shop-ranking2">
-                            <div class="card-header">
-                                <div class="shop-info">
-                                    <div class="shop-info-inner">
-                                        <span class="label-mini-title">[0]</span>
-                                        <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
-                                    </div>
-                                    <div>
-                                        <span class="label-text">-</span>
+                    <!-- END TOP 10 -->
+                    <!-- BEGIN TOP 30 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="ranking-2nd-section-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-2nd-section-body" aria-expanded="false" aria-controls="ranking-2nd-section-body">
+                                    <img class="ico" src="/img/ico-2nd-prize.png">
+                                    <span class="label-title">TOP 30</span>
+                                </button>
+                            </h2>
+                            <div id="ranking-2nd-section-body" class="accordion-collapse collapse" aria-labelledby="ranking-2nd-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-ranking2">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="shop-win-count">
-                                    <div class="shop-win-count-inner">
-                                        <img src="/img/ico-1st-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                        <img src="/img/ico-2nd-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="card-body">
-                                <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </div>
-        <!-- END TOP 30 -->
-        <!-- BEGIN TOP 50 -->
-        <div class="accordion">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="ranking-3rd-section-header">
-                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-3rd-section-body" aria-expanded="false" aria-controls="ranking-3rd-section-body">
-                        <img class="ico" src="/img/ico-3rd-prize.png">
-                        <span class="label-title">TOP 50</span>
-                    </button>
-                </h2>
-                <div id="ranking-3rd-section-body" class="accordion-collapse collapse" aria-labelledby="ranking-3rd-section-header">
-                    <div class="accordion-body">
-                        <div class="card" id="lotto-shop-ranking3">
-                            <div class="card-header">
-                                <div class="shop-info">
-                                    <div class="shop-info-inner">
-                                        <span class="label-mini-title">[0]</span>
-                                        <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
-                                    </div>
-                                    <div>
-                                        <span class="label-text">-</span>
+                    <!-- END TOP 30 -->
+                    <!-- BEGIN TOP 50 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="ranking-3rd-section-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-3rd-section-body" aria-expanded="false" aria-controls="ranking-3rd-section-body">
+                                    <img class="ico" src="/img/ico-3rd-prize.png">
+                                    <span class="label-title">TOP 50</span>
+                                </button>
+                            </h2>
+                            <div id="ranking-3rd-section-body" class="accordion-collapse collapse" aria-labelledby="ranking-3rd-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-ranking3">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="shop-win-count">
-                                    <div class="shop-win-count-inner">
-                                        <img src="/img/ico-1st-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                        <img src="/img/ico-2nd-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="card-body">
-                                <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </div>
-        <!-- END TOP 50 -->
-        <!-- BEGIN TOP 100 -->
-        <div class="accordion">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="ranking-4th-section-header">
-                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-4th-section-body" aria-expanded="false" aria-controls="ranking-4th-section-body">
-                        <img class="ico" src="/img/ico-4th-prize.png">
-                        <span class="label-title">TOP 100</span>
-                    </button>
-                </h2>
-                <div id="ranking-4th-section-body" class="accordion-collapse collapse" aria-labelledby="ranking-4th-section-header">
-                    <div class="accordion-body">
-                        <div class="card" id="lotto-shop-ranking4">
-                            <div class="card-header">
-                                <div class="shop-info">
-                                    <div class="shop-info-inner">
-                                        <span class="label-mini-title">[0]</span>
-                                        <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
-                                    </div>
-                                    <div>
-                                        <span class="label-text">-</span>
+                    <!-- END TOP 50 -->
+                    <!-- BEGIN TOP 100 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="ranking-4th-section-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ranking-4th-section-body" aria-expanded="false" aria-controls="ranking-4th-section-body">
+                                    <img class="ico" src="/img/ico-4th-prize.png">
+                                    <span class="label-title">TOP 100</span>
+                                </button>
+                            </h2>
+                            <div id="ranking-4th-section-body" class="accordion-collapse collapse" aria-labelledby="ranking-4th-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-ranking4">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="shop-win-count">
-                                    <div class="shop-win-count-inner">
-                                        <img src="/img/ico-1st-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                        <img src="/img/ico-2nd-prize.png" class="ico"/>
-                                        <span class="label-text">0</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="card-body">
-                                <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
                             </div>
                         </div>
                     </div>
+                    <!-- END TOP 100 -->
+                </div>
+            </div>
+            <div class="tab-pane fade" id="recent-ranking-content" role="tabpanel" aria-labelledby="recent-ranking-tab">
+                <div class="tab-header">
+                    <span class="label-mini-title label-white">&#9989 최근 52회차 동안의 판매점 배출 등위를 합산한 결과</span>
+                </div>
+                <div class="tab-content-inner">
+                    <!-- BEGIN TOP 10 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="recent-ranking-1st-section-header">
+                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#recent-ranking-1st-section-body" aria-expanded="true" aria-controls="recent-ranking-1st-section-body">
+                                    <img class="ico" src="/img/ico-1st-prize.png">
+                                    <span class="label-title">TOP 10</span>
+                                </button>
+                            </h2>
+                            <div id="recent-ranking-1st-section-body" class="accordion-collapse collapse show" aria-labelledby="recent-ranking-1st-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-recent-ranking1">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- END TOP 10 -->
+                    <!-- BEGIN TOP 30 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="recent-ranking-2nd-section-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#recent-ranking-2nd-section-body" aria-expanded="false" aria-controls="recent-ranking-2nd-section-body">
+                                    <img class="ico" src="/img/ico-2nd-prize.png">
+                                    <span class="label-title">TOP 30</span>
+                                </button>
+                            </h2>
+                            <div id="recent-ranking-2nd-section-body" class="accordion-collapse collapse" aria-labelledby="recent-ranking-2nd-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-recent-ranking2">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- END TOP 30 -->
+                    <!-- BEGIN TOP 50 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="recent-ranking-3rd-section-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#recent-ranking-3rd-section-body" aria-expanded="false" aria-controls="recent-ranking-3rd-section-body">
+                                    <img class="ico" src="/img/ico-3rd-prize.png">
+                                    <span class="label-title">TOP 50</span>
+                                </button>
+                            </h2>
+                            <div id="recent-ranking-3rd-section-body" class="accordion-collapse collapse" aria-labelledby="recent-ranking-3rd-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-recent-ranking3">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- END TOP 50 -->
+                    <!-- BEGIN TOP 100 -->
+                    <div class="accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="recent-ranking-4th-section-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#recent-ranking-4th-section-body" aria-expanded="false" aria-controls="recent-ranking-4th-section-body">
+                                    <img class="ico" src="/img/ico-4th-prize.png">
+                                    <span class="label-title">TOP 100</span>
+                                </button>
+                            </h2>
+                            <div id="recent-ranking-4th-section-body" class="accordion-collapse collapse" aria-labelledby="recent-ranking-4th-section-header">
+                                <div class="accordion-body">
+                                    <div class="card" id="lotto-shop-recent-ranking4">
+                                        <div class="card-header">
+                                            <div class="shop-info">
+                                                <div class="shop-info-inner">
+                                                    <span class="label-mini-title">[0]</span>
+                                                    <span class="label-bold-ellipsis-text">인터넷판매(동행복권)</span>
+                                                </div>
+                                                <div>
+                                                    <span class="label-text">-</span>
+                                                </div>
+                                            </div>
+                                            <div class="shop-win-count">
+                                                <div class="shop-win-count-inner">
+                                                    <img src="/img/ico-1st-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                    <img src="/img/ico-2nd-prize.png" class="ico"/>
+                                                    <span class="label-text">0</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            <span class="label-ellipsis-text">동행복권(dhlottery.co.kr)</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- END TOP 100 -->
                 </div>
             </div>
         </div>
-        <!-- END TOP 100 -->
     </div>
 </main>
 <script src="https://kit.fontawesome.com/9f7c487e95.js" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-<script type="text/javascript" src="/js/footer.js?v=2023061022"></script>
-<script type="text/javascript" src="/js/header.js?v=2023061022"></script>
+<script type="text/javascript" src="/js/footer.js?v=2024030113"></script>
+<script type="text/javascript" src="/js/header.js?v=2024030113"></script>
 <footer id="footer">
     <hr>
     footer 삽입부

--- a/src/main/resources/templates/shop/shopRanking.th.xml
+++ b/src/main/resources/templates/shop/shopRanking.th.xml
@@ -4,7 +4,7 @@
     <attr sel="#footer" th:replace="~{footer :: footer}"/>
 
     <attr sel="#lotto-shop-ranking1"
-          th:each="shop, stat : ${chucked1}"
+          th:each="shop, stat : ${total1}"
           th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
         <attr sel=".card-header">
             <attr sel=".shop-info">
@@ -22,7 +22,7 @@
     </attr>
 
     <attr sel="#lotto-shop-ranking2"
-          th:each="shop, stat : ${chucked2}"
+          th:each="shop, stat : ${total2}"
           th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
         <attr sel=".card-header" th:classappend="'card-header-silver'">
             <attr sel=".shop-info">
@@ -40,7 +40,7 @@
     </attr>
 
     <attr sel="#lotto-shop-ranking3"
-          th:each="shop, stat : ${chucked3}"
+          th:each="shop, stat : ${total3}"
           th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
         <attr sel=".card-header" th:classappend="'card-header-silver'">
             <attr sel=".shop-info">
@@ -58,7 +58,79 @@
     </attr>
 
     <attr sel="#lotto-shop-ranking4"
-          th:each="shop, stat : ${chucked4}"
+          th:each="shop, stat : ${total4}"
+          th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
+        <attr sel=".card-header" th:classappend="'card-header-silver'">
+            <attr sel=".shop-info">
+                <attr sel="div[0]/span[0]" th:text="${'[' + (stat.index + 51) + ']'}"/>
+                <attr sel="div[0]/span[1]" th:text="${shop.name}"/>
+            </attr>
+            <attr sel=".shop-win-count-inner">
+                <attr sel="span[0]" th:text="${#numbers.formatInteger(shop.firstPrizeWinCount, 0, 'COMMA')}"/>
+                <attr sel="span[1]" th:text="${#numbers.formatInteger(shop.secondPrizeWinCount, 0, 'COMMA')}"/>
+            </attr>
+        </attr>
+        <attr sel=".card-body" th:classappend="'card-body-silver'">
+            <attr sel="span[0]" th:text="${shop.address}"/>
+        </attr>
+    </attr>
+
+    <attr sel="#lotto-shop-recent-ranking1"
+          th:each="shop, stat : ${recent1}"
+          th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
+        <attr sel=".card-header">
+            <attr sel=".shop-info">
+                <attr sel="div[0]/span[0]" th:text="${'[' + (stat.index + 1) + ']'}"/>
+                <attr sel="div[0]/span[1]" th:text="${shop.name}"/>
+            </attr>
+            <attr sel=".shop-win-count-inner">
+                <attr sel="span[0]" th:text="${#numbers.formatInteger(shop.firstPrizeWinCount, 0, 'COMMA')}"/>
+                <attr sel="span[1]" th:text="${#numbers.formatInteger(shop.secondPrizeWinCount, 0, 'COMMA')}"/>
+            </attr>
+        </attr>
+        <attr sel=".card-body">
+            <attr sel="span[0]" th:text="${shop.address}"/>
+        </attr>
+    </attr>
+
+    <attr sel="#lotto-shop-recent-ranking2"
+          th:each="shop, stat : ${recent2}"
+          th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
+        <attr sel=".card-header" th:classappend="'card-header-silver'">
+            <attr sel=".shop-info">
+                <attr sel="div[0]/span[0]" th:text="${'[' + (stat.index + 11) + ']'}"/>
+                <attr sel="div[0]/span[1]" th:text="${shop.name}"/>
+            </attr>
+            <attr sel=".shop-win-count-inner">
+                <attr sel="span[0]" th:text="${#numbers.formatInteger(shop.firstPrizeWinCount, 0, 'COMMA')}"/>
+                <attr sel="span[1]" th:text="${#numbers.formatInteger(shop.secondPrizeWinCount, 0, 'COMMA')}"/>
+            </attr>
+        </attr>
+        <attr sel=".card-body" th:classappend="'card-body-silver'">
+            <attr sel="span[0]" th:text="${shop.address}"/>
+        </attr>
+    </attr>
+
+    <attr sel="#lotto-shop-recent-ranking3"
+          th:each="shop, stat : ${recent3}"
+          th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
+        <attr sel=".card-header" th:classappend="'card-header-silver'">
+            <attr sel=".shop-info">
+                <attr sel="div[0]/span[0]" th:text="${'[' + (stat.index + 31) + ']'}"/>
+                <attr sel="div[0]/span[1]" th:text="${shop.name}"/>
+            </attr>
+            <attr sel=".shop-win-count-inner">
+                <attr sel="span[0]" th:text="${#numbers.formatInteger(shop.firstPrizeWinCount, 0, 'COMMA')}"/>
+                <attr sel="span[1]" th:text="${#numbers.formatInteger(shop.secondPrizeWinCount, 0, 'COMMA')}"/>
+            </attr>
+        </attr>
+        <attr sel=".card-body" th:classappend="'card-body-silver'">
+            <attr sel="span[0]" th:text="${shop.address}"/>
+        </attr>
+    </attr>
+
+    <attr sel="#lotto-shop-recent-ranking4"
+          th:each="shop, stat : ${recent4}"
           th:onclick="|location.href='@{/shop(shopId=${shop.id})}'|">
         <attr sel=".card-header" th:classappend="'card-header-silver'">
             <attr sel=".shop-info">


### PR DESCRIPTION
기존 로또명당 페이지 내부에 탭으로 분리하여 신흥명당 목록을 구성했다.

1. 로또명당 - 262회부터 모든 회차의 판매점 배출 등위를 합산한 결과
2. 신흥명당 - 최근 52회차 동안의 판매점 배출 등위를 합산한 결과

This closes #167 