### PR TITLE
safari append child 렌더링 버그 수정

### DIFF
--- a/src/main/resources/static/css/lotto/lottoTool.css
+++ b/src/main/resources/static/css/lotto/lottoTool.css
@@ -94,13 +94,6 @@
     color: white;
 }
 
-.game-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-    margin-top: 5px;
-}
-
 .game-numbers {
     width: 100%;
     border-radius: 5px;
@@ -112,6 +105,7 @@
     align-content: center;
     justify-items: center;
     gap: 5px;
+    margin: 5px 0;
 }
 
 .game-numbers .label-mini-title {


### PR DESCRIPTION
이번 PR 은 safari 브라우저 렌더링 오류를 발견해 조치하기 위한 작업이다.

safari 브라우저에서 로또조합 생성 시, 렌더링이 이상하게 되는 문제를 발견했다.
css 디자인 문제로 파악되어, 수정했다.

This closes #180 