### PR TITLE
관리자페이지 - redis 관리

### DIFF
--- a/src/main/java/com/example/projectlottery/controller/AdminController.java
+++ b/src/main/java/com/example/projectlottery/controller/AdminController.java
@@ -3,7 +3,9 @@ package com.example.projectlottery.controller;
 import com.example.projectlottery.api.service.SeleniumPurchaseService;
 import com.example.projectlottery.api.service.SeleniumScrapService;
 import com.example.projectlottery.domain.type.UserRoleType;
+import com.example.projectlottery.dto.request.AdminRedisRequest;
 import com.example.projectlottery.dto.request.AdminUserRequest;
+import com.example.projectlottery.dto.response.RedisResponse;
 import com.example.projectlottery.dto.response.SeleniumResponse;
 import com.example.projectlottery.dto.response.UserResponse;
 import com.example.projectlottery.service.AdminService;
@@ -44,11 +46,6 @@ public class AdminController {
         map.addAttribute("users", users);
         map.addAttribute("userCnt", users.size());
         map.addAttribute("userRoleTypes", UserRoleType.values());
-
-        //Selenium 탭
-        List<SeleniumResponse> seleniumList = adminService.getAllSeleniumChromeDriverList();
-        map.addAttribute("seleniumList", seleniumList);
-        map.addAttribute("seleniumCnt", seleniumList.size());
 
         return "/user/admin";
     }
@@ -108,6 +105,39 @@ public class AdminController {
                 seleniumPurchaseService.closeWebDriver();
                 redisTemplateService.deletePurchaseWorkerInfo();
             }
+
+            return ResponseEntity.ok().body(null);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(null);
+        }
+    }
+
+    /**
+     * Redis 탭 새로고침 용 GET method
+     * @return Redis 정보를 포함한 Response entity 객체
+     */
+    @ResponseBody
+    @GetMapping("/redis")
+    public ResponseEntity<?> getRedis() {
+        try {
+            List<RedisResponse> results = redisTemplateService.getAllRedisKeyInfo();
+            return ResponseEntity.ok(results);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(null);
+        }
+    }
+
+    @ResponseBody
+    @PostMapping("/redis")
+    public ResponseEntity<?> deleteRedisKey(@RequestBody AdminRedisRequest request) {
+        try {
+            redisTemplateService.deleteByAdmin(
+                    request.type(),
+                    request.key(),
+                    request.field()
+            );
 
             return ResponseEntity.ok().body(null);
 

--- a/src/main/java/com/example/projectlottery/dto/request/AdminRedisRequest.java
+++ b/src/main/java/com/example/projectlottery/dto/request/AdminRedisRequest.java
@@ -1,0 +1,10 @@
+package com.example.projectlottery.dto.request;
+
+import org.springframework.data.redis.connection.DataType;
+
+public record AdminRedisRequest(
+        DataType type,
+        String key,
+        Object field //hash set 에서 세부 field 삭제시에만 사용
+) {
+}

--- a/src/main/java/com/example/projectlottery/dto/response/RedisResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/RedisResponse.java
@@ -1,0 +1,15 @@
+package com.example.projectlottery.dto.response;
+
+import org.springframework.data.redis.connection.DataType;
+
+import java.util.List;
+
+public record RedisResponse(
+        String key,
+        DataType type,
+        Object value, //set 만 사용하는 속성 (실제 값)
+        Long zSetCnt, //sorted set 만 사용하는 속성 (내부 항목 개수)
+        List<Object> hSetFields //hash set 만 사용하는 속성 (내부 필드 key 값 목록)
+) {
+
+}

--- a/src/main/java/com/example/projectlottery/service/RedisTemplateService.java
+++ b/src/main/java/com/example/projectlottery/service/RedisTemplateService.java
@@ -2,6 +2,7 @@ package com.example.projectlottery.service;
 
 import com.example.projectlottery.dto.request.DhLoginRequest;
 import com.example.projectlottery.dto.response.LottoResponse;
+import com.example.projectlottery.dto.response.RedisResponse;
 import com.example.projectlottery.dto.response.ShopResponse;
 import com.example.projectlottery.dto.response.querydsl.QShopSummary;
 import com.example.projectlottery.util.EncryptionUtils;
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -55,6 +57,77 @@ public class RedisTemplateService {
 
         //동행복권 로그인정보는 30분 뒤에 자동으로 파기된다.
         redisTemplate.expire(REDIS_KEY_DH_LOGIN_INFO, 30, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 관리자용 - redis 에서 캐싱된 모든 key 의 정보를 조회한다.
+     * @return redis 캐싱 정보
+     */
+    public List<RedisResponse> getAllRedisKeyInfo() {
+        List<RedisResponse> results = new ArrayList<>();
+
+        //1. redis 에서 관리되는 모든 key 목록을 조회한다.
+        Set<String> keys = redisTemplate.keys("*");
+
+        keys.forEach(k -> {
+            //2. key 가 사용되는 data type 을 체크한다.
+            DataType type = redisTemplate.type(k);
+
+            //3. data type 별 분기처리를 수행한다.
+            Object value = null;
+            List<Object> fields = null;
+            Long cnt = null;
+
+            if (type.equals(DataType.STRING)) {
+                //3-1. 만약, string 이라면, 실제 값을 조회한다.
+                value = redisTemplate.opsForValue().get(k);
+            } else if (type.equals(DataType.ZSET)) {
+                //3-2. 만약, sorted set 이라면, 내부 항목 개수를 조회한다. (랭킹이므로)
+                cnt = redisTemplate.opsForZSet().zCard(k);
+            } else if (type.equals(DataType.HASH)) {
+                //3-3. 만약, hash set 이라면, 세부 필드 키 목록을 조회한다.
+                fields = redisTemplate.opsForHash()
+                        .keys(k)
+                        .stream()
+                        .sorted(Comparator.comparing(Object::toString))
+                        .toList();
+            }
+
+            results.add(new RedisResponse(
+                    k,
+                    type,
+                    value,
+                    cnt,
+                    fields
+            ));
+        });
+
+        //4. data type 순으로 정렬한다.
+        results.sort(Comparator.comparing(RedisResponse::type));
+
+        return results;
+    }
+
+    /**
+     * 관리자용 - 특정 redis cache 를 삭제한다.
+     * @param type data type
+     * @param key cache key
+     * @param field hash set field name - use only hash set
+     */
+    public void deleteByAdmin(DataType type, String key, Object field) {
+        if (type.equals(DataType.HASH)) {
+            //hash set 의 경우, 아래 두 분기로 처리한다.
+            if (field == null) {
+                //1. hash set 전체를 삭제하는 경우
+                redisTemplate.delete(key);
+            } else {
+                //2. hash set 특정 field 만 삭제하는 경우
+                redisTemplate.opsForHash().delete(key, field);
+            }
+        } else {
+            //그 외의 경우는 redis template 에서 키 자체를 삭제한다.
+            redisTemplate.delete(key);
+        }
     }
 
     /**

--- a/src/main/resources/static/css/user/admin.css
+++ b/src/main/resources/static/css/user/admin.css
@@ -54,7 +54,7 @@
     gap: 10px;
 }
 
-.api, .user, .selenium {
+.api, .user, .selenium, .redis {
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -67,16 +67,7 @@
     border: none;
 }
 
-.api-info, .user-info, .selenium-info {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-items: center;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.api-url-with-param, .user-info-detail, .selenium-info-detail {
+.user-info-detail, .api-info-detail, .selenium-info-detail, .redis-info-detail {
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -84,13 +75,25 @@
     justify-content: center;
 }
 
-.api-params {
+.user-info-detail-header, .api-info-detail-header, .selenium-info-detail-header, .redis-info-detail-header {
     width: 100%;
-    height: 24px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    min-height: 30px;
+}
+
+.user-id, .api-url, .selenium-name, .redis-name {
     display: flex;
     flex-direction: row;
     align-items: center;
     align-content: center;
+}
+
+.api-params {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }
 
 .param {
@@ -109,7 +112,7 @@
     margin: 0;
 }
 
-.api-time, .user-modified-at, .selenium-status {
+.api-time, .user-modified-at, .selenium-status, .redis-type {
     width: 100%;
     display: flex;
     flex-direction: row;
@@ -117,7 +120,7 @@
     justify-items: center;
 }
 
-.api-time span, .user-modified-at span {
+.api-time span, .user-modified-at, .selenium-status, .redis-type span {
     color: #666666;
     display: flex;
     justify-content: center;
@@ -130,36 +133,15 @@
     color: white;
 }
 
-.user-info-detail-header {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+.label-special {
+    color: #4caf50;
 }
 
-.user-info-detail-header-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-content: center;
+.label-red {
+    color: red;
 }
 
-.user-id {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    align-content: center;
-}
-
-.user-created-at {
-    width: 100%;
-    height: 24px;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    align-content: center;
-}
-
-.user-roles {
+.user-roles, .hset-fields {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 5px;
@@ -168,10 +150,11 @@
     border-radius: 5px;
     box-shadow: 0 0 2px rgb(64, 135, 216);
     padding: 10px;
+    margin-top: 5px;
     border: none;
 }
 
-.user-role {
+.user-role, .hset-field {
     width: 100%;
     display: flex;
     flex-direction: row;
@@ -204,7 +187,7 @@
     align-items: center;
 }
 
-.btn-refresh {
+.btn-refresh, .btn-delete {
     width: 20px;
     height: 20px;
     padding: 0;
@@ -213,6 +196,12 @@
     justify-content: center;
 }
 
-.btn-refresh {
+.btn-refresh, .btn-delete {
     margin: 0;
+}
+
+.field-name {
+    margin-left: 5px;
+    display: flex;
+    align-items: center;
 }

--- a/src/main/resources/static/js/user/admin.js
+++ b/src/main/resources/static/js/user/admin.js
@@ -33,7 +33,7 @@ function saveUser(idx) {
     });
 }
 
-///
+////////////////////////////////////////////////////////////////////////////////////
 
 const apiStatus = document.getElementById('api-status');
 
@@ -140,7 +140,7 @@ apiRun2Button.addEventListener('click', function () {
     });
 });
 
-///
+////////////////////////////////////////////////////////////////////////////////////
 
 /**
  * API 탭 관련
@@ -206,7 +206,7 @@ apiRun3Button.addEventListener('click', function () {
     });
 });
 
-///
+////////////////////////////////////////////////////////////////////////////////////
 
 const apiRun4Button = document.getElementById('btnApiRun4');
 const apiUrl4 = document.getElementById('apiUrl4');
@@ -280,32 +280,116 @@ function regexUpperCase(param) {
     return regex.test(param);
 }
 
-///
+////////////////////////////////////////////////////////////////////////////////////
 
 /**
  * Selenium 탭 관련
  */
 
+const usages = ['scrap', 'purchase'];
+
 const btnRefreshSeleniumTab = document.getElementById('btn-refresh-selenium-tab');
 btnRefreshSeleniumTab.addEventListener('click', refreshSeleniumTab);
-function refreshSeleniumTab() { //해당 method 는 다른 탭에서 재사용하기 위해 분리시켜 놓았다.
+
+/**
+ * Selenium 새로고침 버튼 처리 method
+ */
+function refreshSeleniumTab() {
     $.ajax({
         type: 'GET',
         url: '/admin/selenium',
         success: function (data) {
-            $.each(data, function(index, item) {
-                const btn = document.getElementById('btnSelenium' + (index + 1));
-                btn.style.display = item.isRunning ? 'block' : 'none';
-
-                const status = document.getElementById('lblSeleniumStatus' + (index + 1));
-                status.innerHTML = item.isRunning ? '&#8987;&nbsp;작업중' : '&#128164;&nbsp;유휴 상태';
-            });
+            makeSeleniumTab(data);
         }
     });
 }
 
-const usages = ['scrap', 'purchase'];
+/**
+ * Selenium 탭 view 생성용 method
+ * @param data Selenium driver 목록 정보 by ajax
+ */
+function makeSeleniumTab(data) {
+    const cntSpan = document.getElementById('selenium-cnt');
+    cntSpan.innerHTML = '&#9989 ' + data.length + '개';
 
+    const grid = document.getElementById('selenium-grid');
+    while (grid.firstChild) {
+        grid.removeChild(grid.firstChild); //기존의 하위 목록 삭제
+    }
+
+    $.each(data, function(index, item) {
+        const unitDiv = document.createElement('div');
+        unitDiv.className = 'selenium';
+
+        const infoDiv = document.createElement('div');
+        infoDiv.className = 'selenium-info';
+
+        const detailDiv = document.createElement('div');
+        detailDiv.className = 'selenium-info-detail';
+
+        const headerDiv = document.createElement('div');
+        headerDiv.className = 'selenium-info-detail-header';
+
+        const nameDiv = document.createElement('div');
+        nameDiv.className = 'selenium-name';
+
+        const idxSpan = document.createElement('span');
+        idxSpan.className = 'label-mini-title';
+        idxSpan.innerHTML = '[' + (index + 1) + ']&nbsp;'
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'label-bold-ellipsis-text';
+        nameSpan.textContent = item.name;
+
+        const suspendBtn = document.createElement('button');
+        suspendBtn.classList.add('btn', 'btn-danger', 'label-mini-title', 'label-white');
+        suspendBtn.id = 'btnSelenium' + (index + 1);
+        suspendBtn.style.display = item.isRunning ? 'block' : 'none';
+        suspendBtn.onclick = () => {
+            suspendSeleniumProcess(index); //usages 는 배열이므로, index 증가없이 사용한다.
+        }
+        suspendBtn.textContent = '중지';
+
+        const usageSpan = document.createElement('span');
+        usageSpan.classList.add('label-mini-title', 'selenium-description');
+        usageSpan.innerHTML = '&#9654;&nbsp; ' + (item.name.endsWith('scrap') ? '동행복권 정보 스크랩핑' : '동행복권 로그인 & 구매');
+
+        const hr = document.createElement('hr');
+        hr.className = 'no-margin-hr';
+
+        const statusDiv = document.createElement('div');
+        statusDiv.className = 'selenium-status';
+
+        const statusSpan = document.createElement('span');
+        statusSpan.className = 'label-mini-title';
+        statusSpan.id = 'lblSeleniumStatus' + (index + 1);
+        statusSpan.innerHTML = item.isRunning ? '&#8987;&nbsp;작업중' : '&#128164;&nbsp;유휴 상태';
+
+        statusDiv.appendChild(statusSpan);
+
+        nameDiv.appendChild(idxSpan);
+        nameDiv.appendChild(nameSpan);
+
+        headerDiv.appendChild(nameDiv);
+        headerDiv.appendChild(suspendBtn);
+
+        detailDiv.appendChild(headerDiv);
+        detailDiv.appendChild(usageSpan);
+
+        infoDiv.appendChild(detailDiv);
+
+        unitDiv.appendChild(infoDiv);
+        unitDiv.appendChild(hr);
+        unitDiv.appendChild(statusDiv);
+
+        grid.appendChild(unitDiv);
+    });
+}
+
+/**
+ * Selenium driver 작업 중지 method
+ * @param idx Driver index
+ */
 function suspendSeleniumProcess(idx) {
     $.ajax({
         type: 'POST',
@@ -324,3 +408,236 @@ function suspendSeleniumProcess(idx) {
     refreshSeleniumTab();
     //TODO: api 탭 새로고침 method 분리하면, 그때 여기 동작시키도록 한다. (둘은 서로 유기적 관계)
 }
+
+////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Redis 탭 관련
+ */
+
+const btnRefreshRedisTab = document.getElementById('btn-refresh-redis-tab');
+btnRefreshRedisTab.addEventListener('click', refreshRedisTab);
+
+/**
+ * Redis 새로고침 버튼 처리 method
+ */
+function refreshRedisTab() {
+    $.ajax({
+        type: 'GET',
+        url: '/admin/redis',
+        success: function (data) {
+            makeRedisTab(data);
+        }
+    });
+}
+
+/**
+ * Redis 탭 view 생성용 method
+ * @param data Redis cache 목록 정보 by ajax
+ */
+function makeRedisTab(data) {
+    const cntSpan = document.getElementById('redis-cnt');
+    cntSpan.innerHTML = '&#128273 ' + data.length + '개';
+
+    const grid = document.getElementById('redis-grid');
+    while (grid.firstChild) {
+        grid.removeChild(grid.firstChild); //기존의 하위 목록 삭제
+    }
+
+    $.each(data, function(index, item) {
+        const unitDiv = document.createElement('div');
+        unitDiv.className = 'redis';
+
+        const infoDiv = document.createElement('div');
+        infoDiv.className = 'redis-info';
+
+        const detailDiv = document.createElement('div');
+        detailDiv.className = 'redis-info-detail';
+
+        const headerDiv = document.createElement('div');
+        headerDiv.className = 'redis-info-detail-header';
+
+        const nameDiv = document.createElement('div');
+        nameDiv.className = 'redis-name';
+
+        const idxSpan = document.createElement('span');
+        idxSpan.className = 'label-mini-title';
+        idxSpan.innerHTML = '[' + (index + 1) + ']&nbsp;'
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'label-bold-ellipsis-text';
+        nameSpan.textContent = item.key;
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.classList.add('btn', 'btn-danger', 'label-mini-title', 'label-white');
+        deleteBtn.id = 'btnRedis' + (index + 1);
+        deleteBtn.onclick = () => {
+            deleteRedisCache(item.type, item.key);
+        }
+        deleteBtn.textContent = '삭제';
+
+        const setDiv = document.createElement('div');
+        setDiv.className = 'redis-set-type';
+        setDiv.style.display = item.type.toString() === 'STRING' ? 'block' : 'none';
+
+        const setSpan1 = document.createElement('span');
+        setSpan1.className = 'label-mini-title';
+        setSpan1.innerHTML = '&#9654;&nbsp;&nbsp;value =&nbsp;';
+
+        const setSpan2 = document.createElement('span');
+        setSpan2.classList.add('label-mini-title', 'label-special');
+        setSpan2.textContent = item.value;
+
+        setDiv.appendChild(setSpan1);
+        setDiv.appendChild(setSpan2);
+
+        const zsetDiv = document.createElement('div');
+        zsetDiv.className = 'redis-zset-type';
+        zsetDiv.style.display = item.type.toString() === 'ZSET' ? 'block' : 'none';
+
+        const zsetSpan1 = document.createElement('span');
+        zsetSpan1.className = 'label-mini-title';
+        zsetSpan1.innerHTML = '&#9654;&nbsp;&nbsp;range =&nbsp;';
+
+        const zsetSpan2 = document.createElement('span');
+        zsetSpan2.classList.add('label-mini-title', 'label-special');
+        zsetSpan2.textContent = '1 ... ' + item.zSetCnt;
+
+        zsetDiv.appendChild(zsetSpan1);
+        zsetDiv.appendChild(zsetSpan2);
+
+        const hsetDiv = document.createElement('div');
+        hsetDiv.className = 'redis-hset-type';
+        hsetDiv.style.display = item.type.toString() === 'HASH' ? 'block' : 'none';
+
+        const hsetSpan = document.createElement('span');
+        hsetSpan.className = 'label-mini-title';
+        hsetSpan.innerHTML = '&#9654;&nbsp;&nbsp;fields';
+
+        const hsetFieldsDiv = document.createElement('div');
+        hsetFieldsDiv.className = 'hset-fields';
+
+        $.each(item.hSetFields, function(idx, itm) {
+            const hsetFieldDiv = document.createElement('div');
+            hsetFieldDiv.className = 'hset-field';
+
+            const hsetFieldDelBtn = document.createElement('button');
+            hsetFieldDelBtn.classList.add('btn', 'btn-danger', 'btn-delete');
+            hsetFieldDelBtn.onclick = () => {
+                deleteRedisCacheForHashSetField(item.type, item.key, itm);
+            }
+
+            const hsetFieldDelBtnSpan = document.createElement('span');
+            hsetFieldDelBtnSpan.classList.add('fas', 'fa-trash', 'label-mini-title', 'label-white');
+
+            hsetFieldDelBtn.appendChild(hsetFieldDelBtnSpan);
+
+            const hsetFieldNameDiv = document.createElement('div');
+            hsetFieldNameDiv.className = 'field-name';
+
+            const hsetFieldNameSpan = document.createElement('span');
+            hsetFieldNameSpan.classList.add('label-mini-title', 'label-special');
+            hsetFieldNameSpan.textContent = itm;
+
+            hsetFieldNameDiv.appendChild(hsetFieldNameSpan);
+
+            hsetFieldDiv.appendChild(hsetFieldDelBtn);
+            hsetFieldDiv.appendChild(hsetFieldNameDiv);
+
+            hsetFieldsDiv.appendChild(hsetFieldDiv);
+        });
+
+        hsetDiv.appendChild(hsetSpan);
+        hsetDiv.appendChild(hsetFieldsDiv);
+
+        const hr = document.createElement('hr');
+        hr.className = 'no-margin-hr';
+
+        const typeDiv = document.createElement('div');
+        typeDiv.className = 'redis-type';
+
+        const typeSpan1 = document.createElement('span');
+        typeSpan1.classList.add('label-text', 'fas', 'fa-database');
+        typeSpan1.innerHTML = '&nbsp;';
+
+        const typeSpan2 = document.createElement('span');
+        typeSpan2.className = 'label-mini-title';
+        typeSpan2.textContent = item.type.toString();
+
+        typeDiv.appendChild(typeSpan1);
+        typeDiv.appendChild(typeSpan2);
+
+        nameDiv.appendChild(idxSpan);
+        nameDiv.appendChild(nameSpan);
+
+        headerDiv.appendChild(nameDiv);
+        headerDiv.appendChild(deleteBtn);
+
+        detailDiv.appendChild(headerDiv);
+        detailDiv.appendChild(setDiv);
+        detailDiv.appendChild(zsetDiv);
+        detailDiv.appendChild(hsetDiv);
+
+        infoDiv.appendChild(detailDiv);
+
+        unitDiv.appendChild(infoDiv);
+        unitDiv.appendChild(hr);
+        unitDiv.appendChild(typeDiv);
+
+        grid.appendChild(unitDiv);
+    });
+}
+
+/**
+ * Redis cache 삭제 method
+ * @param type Cache data type index
+ * @param key Cache key
+ */
+function deleteRedisCache(type, key) {
+    $.ajax({
+        type: 'POST',
+        url: '/admin/redis',
+        data: JSON.stringify({
+            type: type,
+            key: key,
+            field: null
+        }),
+        contentType: 'application/json; charset=utf-8',
+        success: function () {
+            alert('정상적으로 삭제되었습니다.');
+            refreshRedisTab();
+        },
+        error: function () {
+            alert('작업중 오류가 발생했습니다.');
+        }
+    });
+}
+
+/**
+ * Redis cache 삭제 method - Hash set 필드 삭제
+ * @param type Cache data type index
+ * @param key Cache key
+ * @param field Cache field name
+ */
+function deleteRedisCacheForHashSetField(type, key, field) {
+    $.ajax({
+        type: 'POST',
+        url: '/admin/redis',
+        data: JSON.stringify({
+            type: type,
+            key: key,
+            field: field
+        }),
+        contentType: 'application/json; charset=utf-8',
+        success: function () {
+            alert('정상적으로 삭제되었습니다.');
+            refreshRedisTab();
+        },
+        error: function () {
+            alert('작업중 오류가 발생했습니다.');
+        }
+    });
+}
+
+refreshSeleniumTab();
+refreshRedisTab();

--- a/src/main/resources/templates/user/admin.html
+++ b/src/main/resources/templates/user/admin.html
@@ -35,6 +35,11 @@
                     Selenium
                 </button>
             </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link label-text" id="admin-tab-redis" data-bs-toggle="pill" data-bs-target="#admin-content-redis" type="button" role="tab" aria-controls="admin-content-redis" aria-selected="true">
+                    Redis
+                </button>
+            </li>
         </ul>
         <div class="tab-content">
             <!-- 사용자 탭 START -->
@@ -56,18 +61,14 @@
                                 <div class="user-info">
                                     <div class="user-info-detail">
                                         <div class="user-info-detail-header">
-                                            <div  class="user-info-detail-header-wrapper">
-                                                <div class="user-id">
-                                                    <span class="label-mini-title">[1]&nbsp;</span>
-                                                    <span class="label-bold-ellipsis-text">k_2811950709</span>
-                                                    <span class="label-mini-title">&nbsp;(관리자)</span>
-                                                </div>
-                                                <div class="user-created-at">
-                                                    <span class="label-mini-title">&#9654;&nbsp; 1990-01-01 가입</span>
-                                                </div>
+                                            <div class="user-id">
+                                                <span class="label-mini-title">[1]&nbsp;</span>
+                                                <span class="label-bold-ellipsis-text">k_2811950709</span>
+                                                <span class="label-mini-title">&nbsp;(관리자)</span>
                                             </div>
                                             <button class="btn btn-success label-mini-title label-white">저장</button>
                                         </div>
+                                        <span class="label-mini-title user-created-at">&#9654;&nbsp; 1990-01-01 가입</span>
                                         <span class="label-mini-title">&#9654;&nbsp; 권한</span>
                                         <div class="user-roles">
                                             <div class="user-role">
@@ -111,24 +112,25 @@
                         <div class="admin-grid">
                             <div class="api">
                                 <div class="api-info">
-                                    <div class="api-url-with-param">
-                                        <div class="api-url">
-                                            <span class="label-mini-title">[1]</span>
-                                            <span class="label-bold-ellipsis-text">/scrap/L645/win/number</span>
-                                        </div>
-                                        <div class="api-params">
-                                            <div class="param" id="param1">
-                                                <span class="label-mini-title">&#9654;&nbsp; start=&nbsp;</span>
-                                                <input class="form-control label-mini-title" type="text">
+                                    <div class="api-info-detail">
+                                        <div class="api-info-detail-header">
+                                            <div class="api-url">
+                                                <span class="label-mini-title">[1]</span>
+                                                <span class="label-bold-ellipsis-text">/scrap/L645/win/number</span>
                                             </div>
-                                            <div class="param" id="param2">
-                                                <span class="label-mini-title">&nbsp;&&nbsp;</span>
-                                                <span class="label-mini-title">end=&nbsp;</span>
-                                                <input class="form-control label-mini-title" type="text">
-                                            </div>
+                                            <button class="btn">실행</button>
                                         </div>
                                     </div>
-                                    <button class="btn">실행</button>
+                                    <div class="api-params">
+                                        <div class="param" id="param1">
+                                            <span class="label-mini-title">&#9654;&nbsp;start=&nbsp;</span>
+                                            <input class="form-control label-mini-title" type="text">
+                                        </div>
+                                        <div class="param" id="param2">
+                                            <span class="label-mini-title">&#9654;&nbsp; end=&nbsp;</span>
+                                            <input class="form-control label-mini-title" type="text">
+                                        </div>
+                                    </div>
                                 </div>
                                 <hr class="no-margin-hr">
                                 <div class="api-time">
@@ -161,16 +163,19 @@
                             <span class="label-mini-title">현재 상태</span>
                             <span class="label-mini-title">작업</span>
                         </div>
-                        <div class="admin-grid">
+                        <div class="admin-grid" id="selenium-grid">
                             <div class="selenium">
                                 <div class="selenium-info">
                                     <div class="selenium-info-detail">
-                                        <div class="selenium-name">
-                                            <span class="label-mini-title">[1]</span>
-                                            <span class="label-bold-ellipsis-text">Selenium-for-scrap</span>
+                                        <div class="selenium-info-detail-header">
+                                            <div class="selenium-name">
+                                                <span class="label-mini-title">[1]</span>
+                                                <span class="label-bold-ellipsis-text">Selenium-for-scrap</span>
+                                            </div>
+                                            <button class="btn btn-danger label-mini-title label-white">중지</button>
                                         </div>
+                                        <span class="label-mini-title selenium-description">&#9654;&nbsp; 동행복권 정보 스크랩핑</span>
                                     </div>
-                                    <button class="btn btn-danger label-mini-title label-white">중지</button>
                                 </div>
                                 <hr class="no-margin-hr">
                                 <div class="selenium-status">
@@ -182,6 +187,71 @@
                 </div>
             </div>
             <!-- Selenium 탭 END -->
+            
+            <!-- Redis 탭 START -->
+            <div class="tab-pane fade" id="admin-content-redis" role="tabpanel" aria-labelledby="admin-tab-redis">
+                <div class="tab-content-inner">
+                    <span class="label-title">Redis</span>
+                    <br>
+                    <span class="label-mini-title">Redis cache 목록을 모니터링하고 관리합니다.</span>
+                    <hr>
+                    <div class="admin-wrapper">
+                        <div class="header-status">
+                            <span class="label-mini-title" id="redis-cnt">&#128273 0개</span>
+                            <btn class="btn btn-primary btn-refresh" id="btn-refresh-redis-tab">
+                                <span class="fas fa-refresh label-mini-title label-white"></span>
+                            </btn>
+                        </div>
+                        <div class="admin-grid-header">
+                            <span class="label-mini-title">ID</span>
+                            <span class="label-mini-title">데이터 타입</span>
+                            <span class="label-mini-title">작업</span>
+                        </div>
+                        <div class="admin-grid" id="redis-grid">
+                            <div class="redis">
+                                <div class="redis-info">
+                                    <div class="redis-info-detail">
+                                        <div class="redis-info-detail-header">
+                                            <div class="redis-name">
+                                                <span class="label-mini-title">[1]</span>
+                                                <span class="label-bold-ellipsis-text">L645_SHOP_DETAIL</span>
+                                            </div>
+                                            <button class="btn btn-danger label-mini-title label-white">삭제</button>
+                                        </div>
+                                        <div class="redis-set-type">
+                                            <span class="label-mini-title">&#9654;&nbsp;&nbsp;value =&nbsp;</span>
+                                            <span class="label-mini-title label-special"></span>
+                                        </div>
+                                        <div class="redis-zset-type">
+                                            <span class="label-mini-title">&#9654;&nbsp;&nbsp;range =&nbsp;</span>
+                                            <span class="label-mini-title label-special"></span>
+                                        </div>
+                                        <div class="redis-hset-type">
+                                            <span class="label-mini-title">&#9654;&nbsp;&nbsp;fields&nbsp;</span>
+                                            <div class="hset-fields">
+                                                <div class="hset-field">
+                                                    <button class="btn btn-danger btn-delete">
+                                                        <span class="fas fa-trash label-mini-title label-white"></span>
+                                                    </button>
+                                                    <div class="field-name">
+                                                        <span class="label-mini-title label-special"></span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <hr class="no-margin-hr">
+                                <div class="redis-type">
+                                    <span class="label-text fas fa-database">&nbsp;</span>
+                                    <span class="label-mini-title">HSET</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- Redis 탭 END -->
         </div>
     </div>
 </main>

--- a/src/main/resources/templates/user/admin.th.xml
+++ b/src/main/resources/templates/user/admin.th.xml
@@ -19,15 +19,15 @@
                           th:id="${'user-id-' + idx.index}"
                           th:text="${user.userId}"/>
                     <attr sel="span[2]"
+                          th:classappend="${#strings.equals(user.toStringUserRole, '관리자') ? 'label-red' : ''}"
                           th:text="${'&nbsp;(' + user.toStringUserRole + ')'}"/>
-                </attr>
-                <attr sel=".user-created-at">
-                    <attr sel="span[0]"
-                          th:text="${'&#9654;&nbsp; ' + user.toStringCreatedAt + ' 가입'}"/>
                 </attr>
 
                 <attr sel="button"
                       th:onclick="'saveUser(' + ${idx.index} + ')'"/>
+
+                <attr sel=".user-created-at"
+                      th:text="${'&#9654;&nbsp; ' + user.toStringCreatedAt + ' 가입'}"/>
 
                 <attr sel=".user-role"
                       th:each="role: ${userRoleTypes}">
@@ -59,7 +59,7 @@
         <attr sel=".api-info">
             <attr sel=".api-url">
                 <attr sel="span[0]"
-                      th:text="${'[' + (idx.index + 1) + '] '}"/>
+                      th:text="${'[' + (idx.index + 1) + ']&nbsp;'}"/>
                 <attr sel="span[1]"
                       th:id="${'apiUrl' + (idx.index + 1)}"
                       th:text="${api.url}"/>
@@ -94,31 +94,4 @@
     </attr>
 
     <!-- API 탭 END -->
-
-    <!-- Selenium 탭 START -->
-    <attr sel="#selenium-cnt"
-          th:text="${'&#9989 ' + seleniumCnt + '개'}"/>
-
-    <attr sel=".selenium"
-          th:each="selenium, idx: ${seleniumList}">
-        <attr sel=".selenium-info">
-            <attr sel=".selenium-name">
-                <attr sel="span[0]"
-                      th:text="${'[' + (idx.index + 1) + '] '}"/>
-                <attr sel="span[1]"
-                      th:text="${selenium.name}"/>
-            </attr>
-            <attr sel="button"
-                  th:id="${'btnSelenium' + (idx.index + 1)}"
-                  th:style="${#bools.isTrue(selenium.isRunning) ? 'display: block;' : 'display: none;'}"
-                  th:onclick="'suspendSeleniumProcess(' + ${idx.index} + ');'"/>
-        </attr>
-        <attr sel=".selenium-status">
-            <attr sel="span"
-                  th:id="${'lblSeleniumStatus' + (idx.index + 1)}"
-                  th:text="${#bools.isTrue(selenium.isRunning) ? '&#8987;&nbsp;작업중' : '&#128164;&nbsp;유휴 상태'}"/>
-        </attr>
-    </attr>
-
-    <!-- Selenium 탭 END -->
 </thlogic>


### PR DESCRIPTION
이번 PR 은 관리자페이지 내부에서 redis cache 를 관리할 수 있게 하는 기능 개발 작업이다.

한 주의 주요 view 데이터는 성능 향상을 목적으로 redis cache 에 저장하고 사용한다.
왜냐하면, 한 주 동안은 데이터가 갱신되지 않기 때문에 매번 db 를 통할 필요가 없기 때문이다.

그럴 일은 없겠지만, 
혹시 모를 가능성에 대비해 redis cache 목록을 조회하고, 삭제할 수 있도록 했다.

추가적으로 향후 front-end 를 별도 프로젝트로 분리하려고 한다.
그래서 이번 redis 탭 view 에서는 Thymeleaf 를 사용하지 않았다.
구조가 유사한 selenium 탭 역시 이번에 같이 작업해버렸다.

#189 이슈와 관련하여 전체 탭 중에서 2개의 탭은 이미 완료된 것이다.

This closes #183 
