### PR TITLE
관리자페이지 - api 관리 (2)

### DIFF
--- a/src/main/java/com/example/projectlottery/controller/AdminController.java
+++ b/src/main/java/com/example/projectlottery/controller/AdminController.java
@@ -58,8 +58,6 @@ public class AdminController {
         return ResponseEntity.ok().body(null);
     }
 
-    //TODO: API 탭 역시 새로고침을 위한 GET method 를 하나 추가해 준다.
-
     /**
      * API 탭 새로고침용 GET method
      * @return API 정보를 포함한 Response entity 객체

--- a/src/main/java/com/example/projectlottery/dto/response/APIResponse.java
+++ b/src/main/java/com/example/projectlottery/dto/response/APIResponse.java
@@ -3,14 +3,16 @@ package com.example.projectlottery.dto.response;
 public record APIResponse(
         String url,
         String tableName,
-        String modifiedAt
+        String modifiedAt,
+        Long maxDrawNo
 ) {
 
-    public static APIResponse of(String url, String tableName, String modifiedAt) {
+    public static APIResponse of(String url, String tableName, String modifiedAt, Long maxDrawNo) {
         return new APIResponse(
                 url,
                 tableName,
-                modifiedAt
+                modifiedAt,
+                maxDrawNo
         );
     }
 }

--- a/src/main/java/com/example/projectlottery/repository/querydsl/AdminRepositoryCustomImpl.java
+++ b/src/main/java/com/example/projectlottery/repository/querydsl/AdminRepositoryCustomImpl.java
@@ -47,8 +47,9 @@ public class AdminRepositoryCustomImpl extends QuerydslRepositorySupport impleme
                                 Expressions.asString("shop"),
                                 Expressions.stringTemplate(
                                         "DATE_FORMAT({0}, '%Y-%m-%d %H:%i:%s')",
-                                        shop.modifiedAt.max()
-                                )))
+                                        shop.modifiedAt.max()),
+                                Expressions.nullExpression(Long.class) //shop 테이블은 null 값을 가져오도록 한다.
+                                ))
                         .fetch()
         );
 
@@ -59,8 +60,9 @@ public class AdminRepositoryCustomImpl extends QuerydslRepositorySupport impleme
                                 Expressions.asString("lotto"),
                                 Expressions.stringTemplate(
                                         "DATE_FORMAT({0}, '%Y-%m-%d %H:%i:%s')",
-                                        lotto.modifiedAt.max()
-                                )))
+                                        lotto.modifiedAt.max()),
+                                lotto.drawNo.max()
+                        ))
                         .fetch()
         );
 
@@ -71,8 +73,9 @@ public class AdminRepositoryCustomImpl extends QuerydslRepositorySupport impleme
                                 Expressions.asString("lotto_prize"),
                                 Expressions.stringTemplate(
                                         "DATE_FORMAT({0}, '%Y-%m-%d %H:%i:%s')",
-                                        lottoPrize.modifiedAt.max()
-                                )))
+                                        lottoPrize.modifiedAt.max()),
+                                lottoPrize.lotto.drawNo.max()
+                        ))
                         .fetch()
         );
 
@@ -83,8 +86,9 @@ public class AdminRepositoryCustomImpl extends QuerydslRepositorySupport impleme
                                 Expressions.asString("lotto_win_shop"),
                                 Expressions.stringTemplate(
                                         "DATE_FORMAT({0}, '%Y-%m-%d %H:%i:%s')",
-                                        lottoWinShop.modifiedAt.max()
-                                )))
+                                        lottoWinShop.modifiedAt.max()),
+                                lottoWinShop.lotto.drawNo.max()
+                        ))
                         .fetch()
         );
 

--- a/src/main/resources/static/css/user/admin.css
+++ b/src/main/resources/static/css/user/admin.css
@@ -112,7 +112,7 @@
     margin: 0;
 }
 
-.api-time, .user-modified-at, .selenium-status, .redis-type {
+.user-modified-at, .api-time, .api-table-info, .selenium-status, .redis-type {
     width: 100%;
     display: flex;
     flex-direction: row;
@@ -120,7 +120,7 @@
     justify-items: center;
 }
 
-.api-time span, .user-modified-at, .selenium-status, .redis-type span {
+.user-modified-at, .api-time span, .selenium-status, .redis-type span {
     color: #666666;
     display: flex;
     justify-content: center;

--- a/src/main/resources/static/js/user/admin.js
+++ b/src/main/resources/static/js/user/admin.js
@@ -182,6 +182,7 @@ function makeAPITab(data) {
 
         const timeSpan1 = document.createElement('span');
         timeSpan1.classList.add('label-text', 'fas', 'fa-clock');
+        timeSpan1.innerHTML = '&nbsp;';
 
         const timeSpan2 = document.createElement('span');
         timeSpan2.className = 'label-mini-title';
@@ -189,6 +190,26 @@ function makeAPITab(data) {
 
         timeDiv.appendChild(timeSpan1);
         timeDiv.appendChild(timeSpan2);
+
+        const tableDiv = document.createElement('div');
+        tableDiv.className = 'api-table-info';
+        tableDiv.style.display = (index === 0 ? 'none' : '');
+
+        const tableSpan1 = document.createElement('span');
+        tableSpan1.classList.add('label-mini-title', 'label-text', 'fas', 'fa-database');
+        tableSpan1.innerHTML = '&nbsp;';
+
+        const tableSpan2 = document.createElement('span');
+        tableSpan2.className = 'label-mini-title';
+        tableSpan2.innerHTML = 'MAX(draw_no) =&nbsp;';
+
+        const tableSpan3 = document.createElement('span');
+        tableSpan3.classList.add('label-mini-title', 'label-special');
+        tableSpan3.textContent = item.maxDrawNo;
+
+        tableDiv.appendChild(tableSpan1);
+        tableDiv.appendChild(tableSpan2);
+        tableDiv.appendChild(tableSpan3);
 
         headerDiv.appendChild(urlDiv);
         headerDiv.appendChild(execBtn);
@@ -201,6 +222,7 @@ function makeAPITab(data) {
         unitDiv.appendChild(infoDiv);
         unitDiv.appendChild(hr);
         unitDiv.appendChild(timeDiv);
+        unitDiv.appendChild(tableDiv);
 
         grid.appendChild(unitDiv);
     });

--- a/src/main/resources/templates/user/admin.html
+++ b/src/main/resources/templates/user/admin.html
@@ -7,10 +7,10 @@
     <meta name="author" charset="PARK GI-PYO">
     <title>project-lottery</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/common.css?v=2024030511" rel="stylesheet">
-    <link href="/css/header.css?v=2024030511" rel="stylesheet">
-    <link href="/css/footer.css?v=2024030511" rel="stylesheet">
-    <link href="/css/user/admin.css?v=2024030511" rel="stylesheet">
+    <link href="/css/common.css?v=2024033114" rel="stylesheet">
+    <link href="/css/header.css?v=2024033114" rel="stylesheet">
+    <link href="/css/footer.css?v=2024033114" rel="stylesheet">
+    <link href="/css/user/admin.css?v=2024033114" rel="stylesheet">
 </head>
 <body>
 <header id="header">
@@ -137,6 +137,11 @@
                                     <span class="label-text fas fa-clock">&nbsp;</span>
                                     <span class="label-mini-title">1900-01-01 00:00:00</span>
                                 </div>
+                                <div class="api-table-info">
+                                    <span class="label-text fas fa-database">&nbsp;</span>
+                                    <span class="label-mini-title">MAX(draw_no) = </span>
+                                    <span class="label-mini-title label-special">1113</span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -258,9 +263,9 @@
 <script src="https://kit.fontawesome.com/9f7c487e95.js" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-<script type="text/javascript" src="/js/user/admin.js?v=2024030511"></script>
-<script type="text/javascript" src="/js/footer.js?v=2024030511"></script>
-<script type="text/javascript" src="/js/header.js?v=2024030511"></script>
+<script type="text/javascript" src="/js/user/admin.js?v=2024033114"></script>
+<script type="text/javascript" src="/js/footer.js?v=2024033114"></script>
+<script type="text/javascript" src="/js/header.js?v=2024033114"></script>
 <footer id="footer">
     <hr>
     footer 삽입부


### PR DESCRIPTION
이번 PR 은 수동으로 scrap api 실행을 편리하게 할 수 있도록 돕는 표시 항목 추가 작업이다.

view 에서 `일시` 외에 `주요 테이블 필드 max()` 값을 표시하도록 했다.
직관적으로 작업이 안된 항목을 알아보고, 파라미터를 쉽게 채워 실행할 수 있게 했다.

1. win/number - win 테이블의 max(draw_no)
2. win/prize - prize 테이블의 max(draw_no)
3. win/shop - win_shop 테이블의 max(draw_no)

This closes #185 