### PR TITLE
관리자페이지 - user role 즉시 반영

### DIFF
--- a/src/main/java/com/example/projectlottery/config/handler/UserRoleChangeEvent.java
+++ b/src/main/java/com/example/projectlottery/config/handler/UserRoleChangeEvent.java
@@ -1,0 +1,17 @@
+package com.example.projectlottery.config.handler;
+
+import org.springframework.context.ApplicationEvent;
+
+public class UserRoleChangeEvent extends ApplicationEvent {
+
+    private final String userId;
+
+    public UserRoleChangeEvent(Object source, String userId) {
+        super(source);
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/example/projectlottery/config/handler/UserRoleChangeEventListener.java
+++ b/src/main/java/com/example/projectlottery/config/handler/UserRoleChangeEventListener.java
@@ -1,0 +1,56 @@
+package com.example.projectlottery.config.handler;
+
+import com.example.projectlottery.dto.auth.CustomUserDetails;
+import com.example.projectlottery.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserRoleChangeEventListener {
+
+    private final UserService userService;
+
+    /**
+     * UserRoleChangeEvent listener
+     * @param event user role 변경 이벤트
+     */
+    @EventListener
+    public void handleUserRoleChangeEvent(UserRoleChangeEvent event) {
+        //이벤트에서 사용자 id 추출
+        String userId = event.getUserId();
+
+        //security context 에서 사용자 정보 조회
+        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+
+        //security context 에서 사용자 id 추출
+        String currentUserId = userDetails.getUsername();
+
+        //이벤트와 security context 에서의 id 가 동일한지 체크
+        //-> 이벤트가 발행되면 broadcast 되지만, 특정 사용자의 권한만 수정해야 하므로
+        if (currentUserId.equals(userId)) {
+            //role 변경사항을 반영하기 위해 사용자 정보를 새롭게 조회
+            CustomUserDetails currentUserDetails = CustomUserDetails.from(
+                    userService.getUser(userId)
+                            .orElseThrow(() -> new EntityNotFoundException("=== [ERROR] User not found - " + userId))
+            );
+
+            //새롭게 조회한 사용자 정볼르 바탕으로 authentication 객체 생성
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    currentUserDetails, currentUserDetails.getPassword(), currentUserDetails.getAuthorities()
+            );
+
+            //security context 업데이트
+            SecurityContextHolder.getContext()
+                    .setAuthentication(authentication);
+        }
+    }
+}

--- a/src/main/java/com/example/projectlottery/service/AdminService.java
+++ b/src/main/java/com/example/projectlottery/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.example.projectlottery.service;
 
+import com.example.projectlottery.config.handler.UserRoleChangeEvent;
 import com.example.projectlottery.domain.type.UserRoleType;
 import com.example.projectlottery.dto.response.APIWithRunningInfoResponse;
 import com.example.projectlottery.dto.response.SeleniumResponse;
@@ -7,6 +8,7 @@ import com.example.projectlottery.dto.response.UserResponse;
 import com.example.projectlottery.repository.querydsl.AdminRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +25,8 @@ public class AdminService {
     private final RedisTemplateService redisTemplateService;
 
     private final AdminRepositoryCustom adminRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 회원 정보 전체 조회
@@ -46,7 +50,10 @@ public class AdminService {
                         .toList()
         );
 
-
+        //event 발행
+        eventPublisher.publishEvent(
+                new UserRoleChangeEvent(this, userId)
+        );
     }
 
     /**


### PR DESCRIPTION
이번 PR 은 #174 와 직접적으로 관련된 작업이다.

해당 이슈에서 user role 을 수정할 수 있도록 기능을 개발했었다.
(실시간으로 사용자 권한을 관리하여, 코드 수정, 배포 없이 원활한 관리를 위함이었다.)

다만, 문제는 해당 권한이 즉시 반영이 되지 않는 것이었다.
접속 중인 사용자의 권한을 수정했을 경우, security context 가 캐싱되어 있고, 
이를 사용해 재접속하기 전까지는 수정되기 이전의 roles 를 유지하여 즉시 반영이 되지 않았다.

따라서, 즉각적인 반영을 위해서 spring event publish/listener 를 이용했다.

This closes #188 