### PR TITLE
[고도화] selenium - scraper retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.retry:spring-retry'
     implementation 'org.seleniumhq.selenium:selenium-java'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/example/projectlottery/ProjectLotteryApplication.java
+++ b/src/main/java/com/example/projectlottery/ProjectLotteryApplication.java
@@ -3,8 +3,10 @@ package com.example.projectlottery;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableRetry
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/example/projectlottery/api/ScrapScheduler.java
+++ b/src/main/java/com/example/projectlottery/api/ScrapScheduler.java
@@ -9,8 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -27,19 +25,13 @@ public class ScrapScheduler {
      */
     @Scheduled(cron = "0 0 3 * * SAT", zone = "Asia/Seoul")
     public void scrapShopL645() {
-        log.info("=== Started scrapShopL645() : {}", LocalDateTime.now());
-
         try {
             String scrapState = "ALL";
-            scrapLotteryShopService.getShopL645(scrapState);
-        } catch (Exception e) {
-            log.error("=== Failed scrapShopL645() : {}", LocalDateTime.now());
-            log.error(e.getMessage());
-            log.error("=== Failed scrapShopL645() END");
-            return;
-        }
+            scrapLotteryShopService.scrapShopL645(scrapState);
 
-        log.info("=== Success scrapShopL645() : {}", LocalDateTime.now());
+        } catch (Exception e) {
+            //
+        }
     }
 
     /**
@@ -47,19 +39,13 @@ public class ScrapScheduler {
      */
     @Scheduled(cron = "0 45 20 * * SAT", zone = "Asia/Seoul")
     public void scrapWinNumberL645() {
-        log.info("=== Started scrapWinNumberL645() : {}", LocalDateTime.now());
-
         try {
             long drawNo = lottoService.getLatestDrawNo() + 1;
-            scrapLotteryWinService.getWinNumbersL645(drawNo, drawNo);
-        } catch (Exception e) {
-            log.error("=== Failed scrapWinNumberL645() : {}", LocalDateTime.now());
-            log.error(e.getMessage());
-            log.error("=== Failed scrapWinNumberL645() END");
-            return;
-        }
+            scrapLotteryWinService.scrapWinNumbersL645(drawNo, drawNo);
 
-        log.info("=== Success scrapWinNumberL645() : {}", LocalDateTime.now());
+        } catch (Exception e) {
+            //
+        }
     }
 
     /**
@@ -67,19 +53,13 @@ public class ScrapScheduler {
      */
     @Scheduled(cron = "0 0 21 * * SAT", zone = "Asia/Seoul")
     public void scrapWinPrizeL645() {
-        log.info("=== Started scrapWinPrizeL645() : {}", LocalDateTime.now());
-
         try {
             Long drawNo = lottoService.getLatestDrawNo();
-            scrapLotteryWinService.getWinPrizesL645(drawNo, drawNo);
-        } catch (Exception e) {
-            log.error("=== Failed scrapWinPrizeL645() : {}", LocalDateTime.now());
-            log.error(e.getMessage());
-            log.error("=== Failed scrapWinPrizeL645() END");
-            return;
-        }
+            scrapLotteryWinService.scrapWinPrizesL645(drawNo, drawNo);
 
-        log.info("=== Success scrapWinPrizeL645() : {}", LocalDateTime.now());
+        } catch (Exception e) {
+            //
+        }
     }
 
     /**
@@ -87,18 +67,13 @@ public class ScrapScheduler {
      */
     @Scheduled(cron = "0 15 21 * * SAT", zone = "Asia/Seoul")
     public void scrapWinL645Shop() {
-        log.info("=== Started scrapWinL645Shop() : {}", LocalDateTime.now());
-
         try {
             Long drawNo = lottoService.getLatestDrawNo();
-            scrapLotteryWinShopService.getWinShopL645(drawNo, drawNo);
-        } catch (Exception e) {
-            log.error("=== Failed scrapWinL645Shop() : {}", LocalDateTime.now());
-            log.error(e.getMessage());
-            log.error("=== Failed scrapWinL645Shop() END");
-            return;
-        }
+            scrapLotteryWinShopService.scrapWinShopL645(drawNo, drawNo);
 
-        log.info("=== Success scrapWinL645Shop() : {}", LocalDateTime.now());
+
+        } catch (Exception e) {
+            //
+        }
     }
 }

--- a/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinShopService.java
+++ b/src/main/java/com/example/projectlottery/api/service/ScrapLotteryWinShopService.java
@@ -11,11 +11,17 @@ import com.example.projectlottery.service.ShopService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptException;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -33,6 +39,11 @@ public class ScrapLotteryWinShopService {
 
     private final RedisTemplateService redisTemplateService;
 
+    private int retryCount;
+
+    private static final int MAX_RETRY_COUNT = 5;
+    private static final long RETRY_DELAY = 120000; // 2분
+
 
     /**
      * 로또 6/45 당첨 판매점 정보 스크랩핑
@@ -40,19 +51,48 @@ public class ScrapLotteryWinShopService {
      * @param start 시작 회차
      * @param end   종료 회차
      */
-    public void getWinShopL645(long start, long end) {
-        seleniumScrapService.openWebDriver();
-        seleniumScrapService.openUrl(URL_SHOP_WINNING_LOTTO);
+    @Retryable(
+            retryFor = { NoSuchElementException.class, JavascriptException.class },
+            maxAttempts = MAX_RETRY_COUNT,
+            backoff = @Backoff(delay = RETRY_DELAY),
+            recover = "recoverScrap"
+    )
+    public void scrapWinShopL645(Long start, Long end) {
+        log.info("=== Started scrapWinShopL645() : {}", LocalDateTime.now());
 
-        for (long i = start; i <= end; i++) {
-            getWinShopL645_1st(i);
-            getWinShopL645_2nd(i);
+        try {
+            //TODO: 추후, scrap 프로젝트도 별도로 분리되면
+            // redis 가 아닌 다른 방법으로 사용중인지 여부를 관리하는 것으로 바꾸도록 하자. (아마 rest api 통신 할 듯?)
+            String url = "/scrap/L645/win/shop";
+            redisTemplateService.saveScrapRunningInfo(url, start.toString(), end.toString());
+
+            seleniumScrapService.openWebDriver();
+            seleniumScrapService.openUrl(URL_SHOP_WINNING_LOTTO);
+
+            for (long i = start; i <= end; i++) {
+                log.info("=== Processing scrapWinShopL645() 1st - {} : {}", i, LocalDateTime.now());
+                getWinShopL645_1st(i);
+                log.info("=== Processing scrapWinShopL645() 2nd - {} : {}", i, LocalDateTime.now());
+                getWinShopL645_2nd(i);
+            }
+
+            //스크랩핑을 통해 최신 회차 정보가 반영되었기에 cache clear
+            redisTemplateService.flushAllCache();
+
+        } catch (NoSuchElementException e) {
+            log.warn("=== Failed by NoSuchElementException - scrapWinShopL645(), retry 2 min later... ({}/{})", ++retryCount, MAX_RETRY_COUNT);
+
+            throw e;
+
+        } catch (JavascriptException e) {
+            log.warn("=== Failed by JavascriptException - scrapWinShopL645(), retry 2 min later... ({}/{})", ++retryCount, MAX_RETRY_COUNT);
+
+            throw e;
+
+        } finally {
+            redisTemplateService.deleteScrapRunningInfo();
+            seleniumScrapService.closeWebDriver();
         }
-
-        //스크랩핑을 통해 최신 회차 정보가 반영되었기에 cache clear
-        redisTemplateService.flushAllCache();
-
-        seleniumScrapService.closeWebDriver();
     }
 
     /**
@@ -60,7 +100,7 @@ public class ScrapLotteryWinShopService {
      *
      * @param drawNo 회차
      */
-    private void getWinShopL645_1st(long drawNo) {
+    private void getWinShopL645_1st(long drawNo) throws NoSuchElementException, JavascriptException {
         setSelectDrawNo(drawNo);
 
         String js = "document.getElementById('searchBtn').click();";
@@ -89,7 +129,7 @@ public class ScrapLotteryWinShopService {
      *
      * @param drawNo 회차
      */
-    private void getWinShopL645_2nd(long drawNo) {
+    private void getWinShopL645_2nd(long drawNo) throws NoSuchElementException, JavascriptException {
         String css = "#page_box > a";
 
         int pageCount = seleniumScrapService.getElementsByCssSelector(css).size();
@@ -129,7 +169,7 @@ public class ScrapLotteryWinShopService {
      *
      * @param drawNo 회차
      */
-    private void setSelectDrawNo(long drawNo) {
+    private void setSelectDrawNo(long drawNo) throws NoSuchElementException, JavascriptException {
         String css = "#drwNo";
         Select select = new Select(seleniumScrapService.getElementByCssSelector(css));
 
@@ -157,7 +197,7 @@ public class ScrapLotteryWinShopService {
      * @param r         등위
      * @param shopInfos 당첨 판매점 정보 table (WebElement list)
      */
-    private void saveWinShopL645(long drawNo, int r, List<WebElement> shopInfos) {
+    private void saveWinShopL645(long drawNo, int r, List<WebElement> shopInfos) throws NoSuchElementException {
         //당첨 정보 바인딩
         LottoDto lottoDto = lottoService.getLotto(drawNo);
         Integer rank = r;
@@ -225,5 +265,19 @@ public class ScrapLotteryWinShopService {
         );
 
         lottoWinShopService.save(lottoWinShopDto);
+    }
+
+    @Recover
+    private void recoverScrap(NoSuchElementException e, Long start, Long end) {
+        retryCount = 0; //retry count 리셋
+
+        throw e; //예외를 그대로 상위 객체로 던져준다.
+    }
+
+    @Recover
+    private void recoverScrap(JavascriptException e, Long start, Long end) {
+        retryCount = 0; //retry count 리셋
+
+        throw e; //예외를 그대로 상위 객체로 던져준다.
     }
 }

--- a/src/main/java/com/example/projectlottery/api/service/SeleniumPurchaseService.java
+++ b/src/main/java/com/example/projectlottery/api/service/SeleniumPurchaseService.java
@@ -156,16 +156,20 @@ public class SeleniumPurchaseService {
 
     public void procJavaScript(String script) {
         try {
+            //TODO: purchaser 고도화 시, wait 처리 추가 (thread.sleep)
             ((JavascriptExecutor) webDriver).executeScript(script);
         } catch (Exception e) {
+            //TODO: JavascriptException 던지도록 수정할 것
             throw new RuntimeException(e);
         }
     }
 
     public void procJavaScript(String script, Object... args) {
         try {
+            //TODO: purchaser 고도화 시, wait 처리 추가 (thread.sleep)
             ((JavascriptExecutor) webDriver).executeScript(script, args);
         } catch (Exception e) {
+            //TODO: JavascriptException 던지도록 수정할 것
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/example/projectlottery/api/service/SeleniumScrapService.java
+++ b/src/main/java/com/example/projectlottery/api/service/SeleniumScrapService.java
@@ -157,16 +157,22 @@ public class SeleniumScrapService {
     public void procJavaScript(String script) {
         try {
             ((JavascriptExecutor) webDriver).executeScript(script);
+            //javascript executor 는 적절한 wait 옵션이 없어서, 기존처럼 thread sleep 처리
+            Thread.sleep(100);
+
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new JavascriptException("=== Javascript `" + script + "` execute fail.");
         }
     }
 
     public void procJavaScript(String script, Object... args) {
         try {
             ((JavascriptExecutor) webDriver).executeScript(script, args);
+            //javascript executor 는 적절한 wait 옵션이 없어서, 기존처럼 thread sleep 처리
+            Thread.sleep(100);
+
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new JavascriptException("=== Javascript `" + script + "` execute fail.");
         }
     }
 }

--- a/src/main/java/com/example/projectlottery/controller/ScrapController.java
+++ b/src/main/java/com/example/projectlottery/controller/ScrapController.java
@@ -23,7 +23,9 @@ public class ScrapController {
 
     private final RedisTemplateService redisTemplateService;
 
-    //TODO: 각 scrap 함수들 return 을 ResponseEntity 타입으로 바꾸기. (status)
+    //TODO: 각 scrap 함수들 return 을 ResponseEntity 타입으로 바꾸기. (status) - msa 구조, rest api 통신으로 가기위함.
+
+    //TODO: win 관련 scrap 함수 3개 하나로 합칠 수도 있을 거 같다?
 
     /**
      * 동행복권 로또 판매점 정보 scrap 호출 api
@@ -32,18 +34,16 @@ public class ScrapController {
      */
     @GetMapping("/L645/shop")
     public String scrapShop(@RequestParam String state) {
+        // TODO: 추후, scrap 프로젝트도 별도로 분리되면
+        //  webDriver 가 null 인지 체크해서 사용중인지 확인하고 반환하도록 하자. (아마 rest api 통신 할 듯?)
         if (redisTemplateService.getScrapRunningInfo().url() != null)
             return "[scrapShop() - failed] Scraping is already running.";
 
-        String url = "/scrap/L645/shop";
-        redisTemplateService.saveScrapRunningInfo(url, state);
-
         try {
-            scrapLotteryShopService.getShopL645(state);
+            scrapLotteryShopService.scrapShopL645(state);
+
         } catch (Exception e) {
             return e.getMessage();
-        } finally {
-            redisTemplateService.deleteScrapRunningInfo();
         }
 
         return "[scrapShop() - success] state = " + state;
@@ -57,20 +57,18 @@ public class ScrapController {
      */
     @GetMapping("/L645/win/number")
     public String scrapLottoNumber(@RequestParam Long start, @RequestParam(required = false) Long end) {
+        // TODO: 추후, scrap 프로젝트도 별도로 분리되면
+        //  webDriver 가 null 인지 체크해서 사용중인지 확인하고 반환하도록 하자. (아마 rest api 통신 할 듯?)
         if (redisTemplateService.getScrapRunningInfo().url() != null)
             return "[scrapLottoNumber() - failed] Scraping is already running.";
 
         if (Objects.isNull(end)) end = start;
 
-        String url = "/scrap/L645/win/number";
-        redisTemplateService.saveScrapRunningInfo(url, start.toString(), end.toString());
-
         try {
-            scrapLotteryWinService.getWinNumbersL645(start, end);
+            scrapLotteryWinService.scrapWinNumbersL645(start, end);
+
         } catch (Exception e) {
             return e.getMessage();
-        } finally {
-            redisTemplateService.deleteScrapRunningInfo();
         }
 
         return "[scrapLottoNumber() - success] start = " + start + ", end = " + end;
@@ -84,20 +82,17 @@ public class ScrapController {
      */
     @GetMapping("/L645/win/prize")
     public String scrapLottoPrize(@RequestParam Long start, @RequestParam(required = false) Long end) {
+        // TODO: 추후, scrap 프로젝트도 별도로 분리되면
+        //  webDriver 가 null 인지 체크해서 사용중인지 확인하고 반환하도록 하자. (아마 rest api 통신 할 듯?)
         if (redisTemplateService.getScrapRunningInfo().url() != null)
             return "[scrapLottoPrize() - failed] Scraping is already running.";
 
         if (Objects.isNull(end)) end = start;
 
-        String url = "/scrap/L645/win/prize";
-        redisTemplateService.saveScrapRunningInfo(url, start.toString(), end.toString());
-
         try {
-            scrapLotteryWinService.getWinPrizesL645(start, end);
+            scrapLotteryWinService.scrapWinPrizesL645(start, end);
         } catch (Exception e) {
             return e.getMessage();
-        } finally {
-            redisTemplateService.deleteScrapRunningInfo();
         }
 
         return "[scrapLottoPrize() - success] start = " + start + ", end = " + end;
@@ -111,20 +106,17 @@ public class ScrapController {
      */
     @GetMapping("/L645/win/shop")
     public String scrapLottoWinShop(@RequestParam Long start, @RequestParam(required = false) Long end) {
+        // TODO: 추후, scrap 프로젝트도 별도로 분리되면
+        //  webDriver 가 null 인지 체크해서 사용중인지 확인하고 반환하도록 하자. (아마 rest api 통신 할 듯?)
         if (redisTemplateService.getScrapRunningInfo().url() != null)
             return "[scrapLottoWinShop() - failed] Scraping is already running.";
 
         if (Objects.isNull(end)) end = start;
 
-        String url = "/scrap/L645/win/shop";
-        redisTemplateService.saveScrapRunningInfo(url, start.toString(), end.toString());
-
         try {
-            scrapLotteryWinShopService.getWinShopL645(start, end);
+            scrapLotteryWinShopService.scrapWinShopL645(start, end);
         } catch (Exception e) {
             return e.getMessage();
-        } finally {
-            redisTemplateService.deleteScrapRunningInfo();
         }
 
         return "[scrapLottoWinShop() - success] start = " + start + ", end = " + end;

--- a/src/main/java/com/example/projectlottery/domain/type/ScrapStateType.java
+++ b/src/main/java/com/example/projectlottery/domain/type/ScrapStateType.java
@@ -4,23 +4,23 @@ import lombok.Getter;
 
 public enum ScrapStateType {
     ALL("전국"),
-    SEOUL("서울특별시"),
-    GYEONGGI("경기도"),
-    BUSAN("부산광역시"),
-    DAEGU("대구광역시"),
-    INCHEON("인천광역시"),
-    DAEJEON("대전광역시"),
-    ULSAN("울산광역시"),
-    GANGWON("강원도"),
-    CHUNGBUK("충청북도"),
-    CHUNGNAM("충청남도"),
-    GWANGJU("광주광역시"),
-    JEONBUK("전라북도"),
-    JEONNAM("전라남도"),
-    GYEONGBUK("경상북도"),
-    GYEONGNAM("경상남도"),
-    JEJU("제주특별자치도"),
-    SEJONG("세종특별자치시");
+    SEOUL("서울"),
+    GYEONGGI("경기"),
+    BUSAN("부산"),
+    DAEGU("대구"),
+    INCHEON("인천"),
+    DAEJEON("대전"),
+    ULSAN("울산"),
+    GANGWON("강원"),
+    CHUNGBUK("충북"),
+    CHUNGNAM("충남"),
+    GWANGJU("광주"),
+    JEONBUK("전북"),
+    JEONNAM("전남"),
+    GYEONGBUK("경북"),
+    GYEONGNAM("경남"),
+    JEJU("제주"),
+    SEJONG("세종");
 
     @Getter
     private final String description;

--- a/src/main/resources/static/js/user/admin.js
+++ b/src/main/resources/static/js/user/admin.js
@@ -282,7 +282,7 @@ function makeAPITab(data) {
         param1Input.type = 'text';
         param1Input.id = 'api' + (index + 1) + 'Param1';
         param1Input.classList.add('form-control', 'label-mini-title');
-        if (runningParam1 !== null) {
+        if (runningUrl !== null) {
             param1Input.disabled = true;
 
             if (runningUrl === item.url) {
@@ -305,7 +305,7 @@ function makeAPITab(data) {
         param2Input.type = 'text';
         param2Input.id = 'api' + (index + 2) + 'Param2';
         param2Input.classList.add('form-control', 'label-mini-title');
-        if (runningParam2 !== null) {
+        if (runningUrl !== null) {
             param2Input.disabled = true;
 
             if (runningUrl === item.url) {

--- a/src/test/groovy/com/example/projectlottery/api/service/ScrapServiceTest.groovy
+++ b/src/test/groovy/com/example/projectlottery/api/service/ScrapServiceTest.groovy
@@ -37,7 +37,7 @@ class ScrapServiceTest extends IntegrationContainerBaseTest {
         when:
         def oldShops = shopRepository.findAll()
 
-        scrapLotteryShopService.getShopL645(state)
+        scrapLotteryShopService.scrapShopL645(state)
 
         def shops = shopRepository.findAll()
 
@@ -103,7 +103,7 @@ class ScrapServiceTest extends IntegrationContainerBaseTest {
         scrapLotteryWinService.getResultsL645(drawNo, drawNo)
 
         when:
-        scrapLotteryWinShopService.getWinShopL645(drawNo, drawNo)
+        scrapLotteryWinShopService.scrapWinShopL645(drawNo, drawNo)
 
         def lottoWinShops = lottoWinShopRepository.findAll()
 

--- a/src/test/groovy/com/example/projectlottery/service/LottoServiceTest.groovy
+++ b/src/test/groovy/com/example/projectlottery/service/LottoServiceTest.groovy
@@ -41,7 +41,7 @@ class LottoServiceTest extends IntegrationContainerBaseTest {
         if (!isInitialized) {
             //test container 는 빈 상태이므로 초기 데이터 세팅
             scrapLotteryWinService.getResultsL645(1L, 1L)
-            scrapLotteryWinShopService.getWinShopL645(1L, 1L)
+            scrapLotteryWinShopService.scrapWinShopL645(1L, 1L)
         }
 
         testedCount++
@@ -170,7 +170,7 @@ class LottoServiceTest extends IntegrationContainerBaseTest {
         given:
         //262회 이후 당첨 판매점이 정상적으로 제공되는지 확인하기 위해 새로운 회차 스크랩핑
         scrapLotteryWinService.getResultsL645(1059L, 1059L)
-        scrapLotteryWinShopService.getWinShopL645(1059L, 1059L)
+        scrapLotteryWinShopService.scrapWinShopL645(1059L, 1059L)
 
         when:
         def lotto1 = lottoService.getLottoResponse(1L)

--- a/src/test/groovy/com/example/projectlottery/service/ShopServiceTest.groovy
+++ b/src/test/groovy/com/example/projectlottery/service/ShopServiceTest.groovy
@@ -5,7 +5,6 @@ import com.example.projectlottery.api.service.ScrapLotteryShopService
 import com.example.projectlottery.repository.ShopRepository
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.Pageable
 
 import java.time.LocalDate
 
@@ -31,7 +30,7 @@ class ShopServiceTest extends IntegrationContainerBaseTest {
             isInitialized = true
 
             //test container 는 빈 상태이므로 초기 데이터 세팅
-            scrapLotteryShopService.getShopL645("SEJONG")
+            scrapLotteryShopService.scrapShopL645("SEJONG")
         }
 
         testedCount++


### PR DESCRIPTION
이번 PR 은 selenium 을 통한 동행복권 사이트 scrap 시, 동작 안정성 제고를 위한 작업이다.

그 동안 스크랩핑이 모두 정상 완료된 회차가 있는가 하면, 부분 완료된 회차도 간혹 있었다.
심각한 지연이 아니라면, 약간의 딜레이는 retry 하여 알아서 재처리할 수 있도록 개선했다.

** 추첨결과 관련 scrap 실패 시, 5회 까지 retry (term = 2min)
추첨결과 관련 scrap 스케쥴이 15분 간격이므로, 5 * 2min = 10min 으로 이 정도면 충분해 보인다.

This closes #200 