### PR TITLE
[긴급] 동행복권 구매내역 조회 URL 수정

### DIFF
--- a/src/main/java/com/example/projectlottery/api/service/PurchaseLotteryService.java
+++ b/src/main/java/com/example/projectlottery/api/service/PurchaseLotteryService.java
@@ -151,7 +151,7 @@ public class PurchaseLotteryService {
             int purchasableCnt = 5; //온라인은 회차당 5매 제한이 있어서 구매 내역에서 조회된 매수만큼 빼줘야 한다.
 
             //최근 7일간 구매내역 확인창 오픈
-            MessageFormat iframeURL = new MessageFormat("https://dhlottery.co.kr/myPage.do?method=lottoBuyList&searchStartDate={0}&searchEndDate={1}&lottoId=LO40&nowPage=1");
+            MessageFormat iframeURL = new MessageFormat("https://dhlottery.co.kr/myPage.do?method=lottoBuyList&searchStartDate={0}&searchEndDate={1}&lottoId=LO40&winGrade=2");
             String startDt = getPreviousSunday();
             String endDt = getNextSaturday();
             seleniumPurchaseService.openUrl(iframeURL.format(new Object[] {startDt, endDt}));


### PR DESCRIPTION
이번 PR 은 구매가능 매수 계산이 정상적으로 되지 않는 문제를 해결하기 위한 작업이다.

이를 해결하기 위해 URL query param 을 수정했다.
`winGrade` 라는 parameter 가 추가적으로 필요해졌다.

This closes #213 